### PR TITLE
feat: implement GPS L1 subframe 4 and 5 decoding

### DIFF
--- a/src/gpsl1.jl
+++ b/src/gpsl1.jl
@@ -55,6 +55,42 @@ Base.@kwdef struct GPSL1Data <: AbstractGNSSData
     Ω_dot::Union{Nothing,Float64} = nothing
     IODE_Sub_3::Union{Nothing,String} = nothing
     i_dot::Union{Nothing,Float64} = nothing
+
+    # Subframe 4 page 18: Ionospheric parameters
+    α_0::Union{Nothing,Float64} = nothing
+    α_1::Union{Nothing,Float64} = nothing
+    α_2::Union{Nothing,Float64} = nothing
+    α_3::Union{Nothing,Float64} = nothing
+    β_0::Union{Nothing,Float64} = nothing
+    β_1::Union{Nothing,Float64} = nothing
+    β_2::Union{Nothing,Float64} = nothing
+    β_3::Union{Nothing,Float64} = nothing
+
+    # Subframe 4 page 18: UTC parameters
+    A_0::Union{Nothing,Float64} = nothing
+    A_1::Union{Nothing,Float64} = nothing
+    Δt_LS::Union{Nothing,Int64} = nothing
+    t_ot::Union{Nothing,Int64} = nothing
+    WN_t::Union{Nothing,Int64} = nothing
+    WN_LSF::Union{Nothing,Int64} = nothing
+    DN::Union{Nothing,Int64} = nothing
+    Δt_LSF::Union{Nothing,Int64} = nothing
+
+    # Subframe 4 page 25: A-S flags and SV configurations (32 SVs)
+    sv_config::Union{Nothing,Vector{Int64}} = nothing
+
+    # Subframe 4 page 25: SV health for SV 25-32 (6-bit health words)
+    sv_health_sf4_25::Union{Nothing,Vector{String}} = nothing
+
+    # Subframe 5 pages 1-24: Almanac data (stored per SV ID)
+    almanac::Union{Nothing,Dict{Int64,NamedTuple}} = nothing
+
+    # Subframe 5 page 25: SV health for SV 1-24 (6-bit health words)
+    sv_health_sf5_25::Union{Nothing,Vector{String}} = nothing
+
+    # Subframe 5 page 25: Almanac reference time and week
+    t_oa::Union{Nothing,Int64} = nothing
+    WN_a::Union{Nothing,Int64} = nothing
 end
 
 function GPSL1Data(
@@ -95,6 +131,28 @@ function GPSL1Data(
     Ω_dot = data.Ω_dot,
     IODE_Sub_3 = data.IODE_Sub_3,
     i_dot = data.i_dot,
+    α_0 = data.α_0,
+    α_1 = data.α_1,
+    α_2 = data.α_2,
+    α_3 = data.α_3,
+    β_0 = data.β_0,
+    β_1 = data.β_1,
+    β_2 = data.β_2,
+    β_3 = data.β_3,
+    A_0 = data.A_0,
+    A_1 = data.A_1,
+    Δt_LS = data.Δt_LS,
+    t_ot = data.t_ot,
+    WN_t = data.WN_t,
+    WN_LSF = data.WN_LSF,
+    DN = data.DN,
+    Δt_LSF = data.Δt_LSF,
+    sv_config = data.sv_config,
+    sv_health_sf4_25 = data.sv_health_sf4_25,
+    almanac = data.almanac,
+    sv_health_sf5_25 = data.sv_health_sf5_25,
+    t_oa = data.t_oa,
+    WN_a = data.WN_a,
 )
     GPSL1Data(
         last_subframe_id,
@@ -133,6 +191,28 @@ function GPSL1Data(
         Ω_dot,
         IODE_Sub_3,
         i_dot,
+        α_0,
+        α_1,
+        α_2,
+        α_3,
+        β_0,
+        β_1,
+        β_2,
+        β_3,
+        A_0,
+        A_1,
+        Δt_LS,
+        t_ot,
+        WN_t,
+        WN_LSF,
+        DN,
+        Δt_LSF,
+        sv_config,
+        sv_health_sf4_25,
+        almanac,
+        sv_health_sf5_25,
+        t_oa,
+        WN_a,
     )
 end
 
@@ -190,11 +270,34 @@ function is_subframe3_decoded(data::GPSL1Data)
 end
 
 function is_subframe4_decoded(data::GPSL1Data)
-    false
+    # Subframe 4 is considered decoded when we have ionospheric and UTC parameters
+    # (page 18) and SV configurations/health (page 25)
+    !isnothing(data.α_0) &&
+        !isnothing(data.α_1) &&
+        !isnothing(data.α_2) &&
+        !isnothing(data.α_3) &&
+        !isnothing(data.β_0) &&
+        !isnothing(data.β_1) &&
+        !isnothing(data.β_2) &&
+        !isnothing(data.β_3) &&
+        !isnothing(data.A_0) &&
+        !isnothing(data.A_1) &&
+        !isnothing(data.Δt_LS) &&
+        !isnothing(data.t_ot) &&
+        !isnothing(data.WN_t) &&
+        !isnothing(data.WN_LSF) &&
+        !isnothing(data.DN) &&
+        !isnothing(data.Δt_LSF) &&
+        !isnothing(data.sv_config) &&
+        !isnothing(data.sv_health_sf4_25)
 end
 
 function is_subframe5_decoded(data::GPSL1Data)
-    false
+    # Subframe 5 is considered decoded when we have SV health (page 25)
+    # and almanac reference time/week
+    !isnothing(data.sv_health_sf5_25) &&
+        !isnothing(data.t_oa) &&
+        !isnothing(data.WN_a)
 end
 
 function is_decoding_completed_for_positioning(data::GPSL1Data)
@@ -557,7 +660,349 @@ function decode_syncro_sequence(state::GNSSDecoderState{<:GPSL1Data})
                 get_twos_complement_num(word10, 30, 9, 14) * state.constants.PI / 1 << 43
             GPSL1Data(state.raw_data; IODE_Sub_3, i_dot)
         end
+    elseif subframe_id == 4
+        # Get page ID (SV ID) from word 3 bits 3-8
+        state = can_decode_word(state, 3) do word3, state
+            sv_page_id = get_bits(word3, 30, 3, 6)
+            GPSL1Data(state.raw_data; last_subframe_id = 4 + sv_page_id * 100) # encode page in subframe_id temporarily
+        end
+        sv_page_id = (state.raw_data.last_subframe_id - 4) ÷ 100
+        state = GNSSDecoderState(state; raw_data = GPSL1Data(state.raw_data; last_subframe_id = 4))
+
+        if sv_page_id == 56 # Page 18: Ionospheric and UTC data
+            state = decode_subframe4_page18(state)
+        elseif sv_page_id == 63 # Page 25: A-S flags and SV health
+            state = decode_subframe4_page25(state)
+        elseif sv_page_id in 25:32 # Pages 2-5, 7-10: Almanac for SV 25-32
+            state = decode_almanac_page(state, sv_page_id)
+        end
+    elseif subframe_id == 5
+        # Get SV ID from word 3 bits 3-8
+        state = can_decode_word(state, 3) do word3, state
+            sv_id = get_bits(word3, 30, 3, 6)
+            GPSL1Data(state.raw_data; last_subframe_id = 5 + sv_id * 100) # encode SV ID temporarily
+        end
+        sv_id = (state.raw_data.last_subframe_id - 5) ÷ 100
+        state = GNSSDecoderState(state; raw_data = GPSL1Data(state.raw_data; last_subframe_id = 5))
+
+        if sv_id == 51 # Page 25: SV health and almanac reference
+            state = decode_subframe5_page25(state)
+        elseif sv_id in 1:24 # Pages 1-24: Almanac for SV 1-24
+            state = decode_almanac_page(state, sv_id)
+        end
     end
+
+    return state
+end
+
+function decode_subframe4_page18(state::GNSSDecoderState{<:GPSL1Data})
+    # Page 18 contains ionospheric parameters and UTC parameters
+    # Word 3: bits 9-16 = α0, bits 17-24 = α1
+    # Word 4: bits 1-8 = α2, bits 9-16 = α3, bits 17-24 = β0
+    # Word 5: bits 1-8 = β1, bits 9-16 = β2, bits 17-24 = β3
+    # Word 6: bits 1-24 = A1 (24 bits)
+    # Word 7: bits 1-24 = A0 MSBs (24 bits)
+    # Word 8: bits 1-8 = A0 LSBs (8 bits), bits 9-16 = tot, bits 17-24 = WNt
+    # Word 9: bits 1-8 = ΔtLS, bits 9-16 = WNLSF, bits 17-24 = DN
+    # Word 10: bits 1-8 = ΔtLSF
+
+    state = can_decode_word(state, 3) do word3, state
+        α_0 = get_twos_complement_num(word3, 30, 9, 8) / 1 << 30
+        α_1 = get_twos_complement_num(word3, 30, 17, 8) / 1 << 27
+        GPSL1Data(state.raw_data; α_0, α_1)
+    end
+
+    state = can_decode_word(state, 4) do word4, state
+        α_2 = get_twos_complement_num(word4, 30, 1, 8) / 1 << 24
+        α_3 = get_twos_complement_num(word4, 30, 9, 8) / 1 << 24
+        β_0 = get_twos_complement_num(word4, 30, 17, 8) * (1 << 11)
+        GPSL1Data(state.raw_data; α_2, α_3, β_0)
+    end
+
+    state = can_decode_word(state, 5) do word5, state
+        β_1 = get_twos_complement_num(word5, 30, 1, 8) * (1 << 14)
+        β_2 = get_twos_complement_num(word5, 30, 9, 8) * (1 << 16)
+        β_3 = get_twos_complement_num(word5, 30, 17, 8) * (1 << 16)
+        GPSL1Data(state.raw_data; β_1, β_2, β_3)
+    end
+
+    state = can_decode_word(state, 6) do word6, state
+        A_1 = get_twos_complement_num(word6, 30, 1, 24) / 1 << 50
+        GPSL1Data(state.raw_data; A_1)
+    end
+
+    state = can_decode_two_words(state, 7, 8) do word7, word8, state
+        # A0 is 32 bits: 24 MSBs in word 7, 8 LSBs in word 8
+        combined_word = UInt(get_bits(word7, 30, 1, 24) << 8 + get_bits(word8, 30, 1, 8))
+        A_0 = get_twos_complement_num(combined_word, 32, 1, 32) / 1 << 30
+        GPSL1Data(state.raw_data; A_0)
+    end
+
+    state = can_decode_word(state, 8) do word8, state
+        t_ot = get_bits(word8, 30, 9, 8) << 12
+        WN_t = get_bits(word8, 30, 17, 8)
+        GPSL1Data(state.raw_data; t_ot, WN_t)
+    end
+
+    state = can_decode_word(state, 9) do word9, state
+        Δt_LS = get_twos_complement_num(word9, 30, 1, 8)
+        WN_LSF = get_bits(word9, 30, 9, 8)
+        DN = get_bits(word9, 30, 17, 8)
+        GPSL1Data(state.raw_data; Δt_LS, WN_LSF, DN)
+    end
+
+    state = can_decode_word(state, 10) do word10, state
+        Δt_LSF = get_twos_complement_num(word10, 30, 1, 8)
+        GPSL1Data(state.raw_data; Δt_LSF)
+    end
+
+    return state
+end
+
+function decode_subframe4_page25(state::GNSSDecoderState{<:GPSL1Data})
+    # Page 25 contains A-S flags and SV configurations for 32 SVs
+    # and SV health for SV 25-32
+    # Word 3: bits 9-24 = 4 SVs config (4 bits each)
+    # Words 4-7: 24 MSBs = 6 SVs config each (4 bits each)
+    # Word 8: bits 1-16 = 4 SVs config, bits 19-24 = SV25 health (6 bits)
+    # Word 9: bits 1-24 = SV26-29 health (6 bits each)
+    # Word 10: bits 1-18 = SV30-32 health (6 bits each)
+
+    # Decode SV configurations (32 x 4-bit values)
+    sv_config = Vector{Int64}(undef, 32)
+
+    state = can_decode_word(state, 3) do word3, state
+        for i in 1:4
+            sv_config[i] = get_bits(word3, 30, 9 + (i - 1) * 4, 4)
+        end
+        GPSL1Data(state.raw_data; sv_config)
+    end
+
+    state = can_decode_word(state, 4) do word4, state
+        cfg = something(state.raw_data.sv_config, Vector{Int64}(undef, 32))
+        for i in 1:6
+            cfg[4 + i] = get_bits(word4, 30, 1 + (i - 1) * 4, 4)
+        end
+        GPSL1Data(state.raw_data; sv_config = cfg)
+    end
+
+    state = can_decode_word(state, 5) do word5, state
+        cfg = something(state.raw_data.sv_config, Vector{Int64}(undef, 32))
+        for i in 1:6
+            cfg[10 + i] = get_bits(word5, 30, 1 + (i - 1) * 4, 4)
+        end
+        GPSL1Data(state.raw_data; sv_config = cfg)
+    end
+
+    state = can_decode_word(state, 6) do word6, state
+        cfg = something(state.raw_data.sv_config, Vector{Int64}(undef, 32))
+        for i in 1:6
+            cfg[16 + i] = get_bits(word6, 30, 1 + (i - 1) * 4, 4)
+        end
+        GPSL1Data(state.raw_data; sv_config = cfg)
+    end
+
+    state = can_decode_word(state, 7) do word7, state
+        cfg = something(state.raw_data.sv_config, Vector{Int64}(undef, 32))
+        for i in 1:6
+            cfg[22 + i] = get_bits(word7, 30, 1 + (i - 1) * 4, 4)
+        end
+        GPSL1Data(state.raw_data; sv_config = cfg)
+    end
+
+    state = can_decode_word(state, 8) do word8, state
+        cfg = something(state.raw_data.sv_config, Vector{Int64}(undef, 32))
+        for i in 1:4
+            cfg[28 + i] = get_bits(word8, 30, 1 + (i - 1) * 4, 4)
+        end
+        # SV 25 health (6 bits) at bits 19-24
+        sv_health_sf4_25 = Vector{String}(undef, 8)
+        sv_health_sf4_25[1] = bitstring(get_bits(word8, 30, 19, 6))[end-5:end]
+        GPSL1Data(state.raw_data; sv_config = cfg, sv_health_sf4_25)
+    end
+
+    state = can_decode_word(state, 9) do word9, state
+        health = something(state.raw_data.sv_health_sf4_25, Vector{String}(undef, 8))
+        for i in 1:4
+            health[1 + i] = bitstring(get_bits(word9, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf4_25 = health)
+    end
+
+    state = can_decode_word(state, 10) do word10, state
+        health = something(state.raw_data.sv_health_sf4_25, Vector{String}(undef, 8))
+        for i in 1:3
+            health[5 + i] = bitstring(get_bits(word10, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf4_25 = health)
+    end
+
+    return state
+end
+
+function decode_subframe5_page25(state::GNSSDecoderState{<:GPSL1Data})
+    # Page 25 contains SV health for SV 1-24 and almanac reference time/week
+    # Word 3: bits 9-16 = toa, bits 17-24 = WNa
+    # Word 4: bits 1-24 = SV1-4 health (6 bits each)
+    # Word 5-8: bits 1-24 = SV health (6 bits each, 4 SVs per word)
+    # Word 9: bits 1-24 = SV21-24 health (6 bits each)
+
+    state = can_decode_word(state, 3) do word3, state
+        t_oa = get_bits(word3, 30, 9, 8) << 12
+        WN_a = get_bits(word3, 30, 17, 8)
+        GPSL1Data(state.raw_data; t_oa, WN_a)
+    end
+
+    sv_health_sf5_25 = Vector{String}(undef, 24)
+
+    state = can_decode_word(state, 4) do word4, state
+        for i in 1:4
+            sv_health_sf5_25[i] = bitstring(get_bits(word4, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf5_25)
+    end
+
+    state = can_decode_word(state, 5) do word5, state
+        health = something(state.raw_data.sv_health_sf5_25, Vector{String}(undef, 24))
+        for i in 1:4
+            health[4 + i] = bitstring(get_bits(word5, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf5_25 = health)
+    end
+
+    state = can_decode_word(state, 6) do word6, state
+        health = something(state.raw_data.sv_health_sf5_25, Vector{String}(undef, 24))
+        for i in 1:4
+            health[8 + i] = bitstring(get_bits(word6, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf5_25 = health)
+    end
+
+    state = can_decode_word(state, 7) do word7, state
+        health = something(state.raw_data.sv_health_sf5_25, Vector{String}(undef, 24))
+        for i in 1:4
+            health[12 + i] = bitstring(get_bits(word7, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf5_25 = health)
+    end
+
+    state = can_decode_word(state, 8) do word8, state
+        health = something(state.raw_data.sv_health_sf5_25, Vector{String}(undef, 24))
+        for i in 1:4
+            health[16 + i] = bitstring(get_bits(word8, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf5_25 = health)
+    end
+
+    state = can_decode_word(state, 9) do word9, state
+        health = something(state.raw_data.sv_health_sf5_25, Vector{String}(undef, 24))
+        for i in 1:4
+            health[20 + i] = bitstring(get_bits(word9, 30, 1 + (i - 1) * 6, 6))[end-5:end]
+        end
+        GPSL1Data(state.raw_data; sv_health_sf5_25 = health)
+    end
+
+    return state
+end
+
+function decode_almanac_page(state::GNSSDecoderState{<:GPSL1Data}, sv_id::Int)
+    # Almanac pages (subframe 4 pages 2-5, 7-10 for SV 25-32;
+    #                subframe 5 pages 1-24 for SV 1-24)
+    # Word 3: bits 9-24 = e (16 bits)
+    # Word 4: bits 1-8 = toa, bits 9-24 = δi (16 bits)
+    # Word 5: bits 1-16 = Ω_dot, bits 17-24 = SV health (8 bits)
+    # Word 6: bits 1-24 = √A (24 bits)
+    # Word 7: bits 1-24 = Ω0 (24 bits)
+    # Word 8: bits 1-24 = ω (24 bits)
+    # Word 9: bits 1-24 = M0 (24 bits)
+    # Word 10: bits 1-8 = af0 MSBs (8 bits), bits 9-19 = af1 (11 bits), bits 20-22 = af0 LSBs (3 bits)
+
+    if sv_id == 0
+        # Dummy SV, skip decoding
+        return state
+    end
+
+    # Decode all almanac words and build the almanac entry
+    # We need to decode all words and check parity for each
+    word3 = get_word(state, 3)
+    word4 = get_word(state, 4)
+    word5 = get_word(state, 5)
+    word6 = get_word(state, 6)
+    word7 = get_word(state, 7)
+    word8 = get_word(state, 8)
+    word9 = get_word(state, 9)
+    word10 = get_word(state, 10)
+
+    # Check parity for all words
+    prev_word2 = get_word(state, 2)
+    prev_word3 = get_word(state, 3)
+    prev_word4 = get_word(state, 4)
+    prev_word5 = get_word(state, 5)
+    prev_word6 = get_word(state, 6)
+    prev_word7 = get_word(state, 7)
+    prev_word8 = get_word(state, 8)
+    prev_word9 = get_word(state, 9)
+
+    parity_ok =
+        check_gpsl1_parity(word3, get_bit(prev_word2, 30, 29), get_bit(prev_word2, 30, 30)) &&
+        check_gpsl1_parity(word4, get_bit(prev_word3, 30, 29), get_bit(prev_word3, 30, 30)) &&
+        check_gpsl1_parity(word5, get_bit(prev_word4, 30, 29), get_bit(prev_word4, 30, 30)) &&
+        check_gpsl1_parity(word6, get_bit(prev_word5, 30, 29), get_bit(prev_word5, 30, 30)) &&
+        check_gpsl1_parity(word7, get_bit(prev_word6, 30, 29), get_bit(prev_word6, 30, 30)) &&
+        check_gpsl1_parity(word8, get_bit(prev_word7, 30, 29), get_bit(prev_word7, 30, 30)) &&
+        check_gpsl1_parity(word9, get_bit(prev_word8, 30, 29), get_bit(prev_word8, 30, 30)) &&
+        check_gpsl1_parity(word10, get_bit(prev_word9, 30, 29), get_bit(prev_word9, 30, 30))
+
+    if !parity_ok
+        return state
+    end
+
+    # Apply bit complement if needed based on prev word bit 30
+    word3_comp = get_bit(prev_word2, 30, 30) ? ~word3 : word3
+    word4_comp = get_bit(prev_word3, 30, 30) ? ~word4 : word4
+    word5_comp = get_bit(prev_word4, 30, 30) ? ~word5 : word5
+    word6_comp = get_bit(prev_word5, 30, 30) ? ~word6 : word6
+    word7_comp = get_bit(prev_word6, 30, 30) ? ~word7 : word7
+    word8_comp = get_bit(prev_word7, 30, 30) ? ~word8 : word8
+    word9_comp = get_bit(prev_word8, 30, 30) ? ~word9 : word9
+    word10_comp = get_bit(prev_word9, 30, 30) ? ~word10 : word10
+
+    # Decode almanac parameters
+    alm_e = get_bits(word3_comp, 30, 9, 16) / 1 << 21
+    alm_toa = get_bits(word4_comp, 30, 1, 8) << 12
+    alm_δi = get_twos_complement_num(word4_comp, 30, 9, 16) * state.constants.PI / 1 << 19
+    alm_Ω_dot = get_twos_complement_num(word5_comp, 30, 1, 16) * state.constants.PI / 1 << 38
+    alm_sv_health = bitstring(get_bits(word5_comp, 30, 17, 8))[end-7:end]
+    alm_sqrt_A = get_bits(word6_comp, 30, 1, 24) / 1 << 11
+    alm_Ω_0 = get_twos_complement_num(word7_comp, 30, 1, 24) * state.constants.PI / 1 << 23
+    alm_ω = get_twos_complement_num(word8_comp, 30, 1, 24) * state.constants.PI / 1 << 23
+    alm_M_0 = get_twos_complement_num(word9_comp, 30, 1, 24) * state.constants.PI / 1 << 23
+
+    # af0: 8 MSBs at bits 1-8, 3 LSBs at bits 20-22 = 11 bits total
+    af0_msbs = get_bits(word10_comp, 30, 1, 8)
+    af0_lsbs = get_bits(word10_comp, 30, 20, 3)
+    af0_combined = UInt(af0_msbs << 3 + af0_lsbs)
+    alm_af0 = get_twos_complement_num(af0_combined, 11, 1, 11) / 1 << 20
+    alm_af1 = get_twos_complement_num(word10_comp, 30, 9, 11) / 1 << 38
+
+    # Store almanac data for this SV
+    almanac_entry = (
+        e = alm_e,
+        t_oa = alm_toa,
+        δi = alm_δi,
+        Ω_dot = alm_Ω_dot,
+        sv_health = alm_sv_health,
+        sqrt_A = alm_sqrt_A,
+        Ω_0 = alm_Ω_0,
+        ω = alm_ω,
+        M_0 = alm_M_0,
+        af0 = alm_af0,
+        af1 = alm_af1,
+    )
+
+    almanac = something(state.raw_data.almanac, Dict{Int64,NamedTuple}())
+    almanac[sv_id] = almanac_entry
+    state = GNSSDecoderState(state; raw_data = GPSL1Data(state.raw_data; almanac))
 
     return state
 end

--- a/test/gpsl1.jl
+++ b/test/gpsl1.jl
@@ -1,7 +1,19 @@
-BitIntegers.@define_integers 1536
+BitIntegers.@define_integers 4000
 BitIntegers.@define_integers 320
-const GPSL1DATA =
-    uint1536"0x8b010c06ef056f410d000004def4351756ed43ed2357f4afe163920d2f0bff00295b9ebf9f88b010c06ef035644808d518abf98cb9d2094bfe1c3e92dbb769706d42853f19a83172d0e0748b010c06ef014ecffa302d1c9d38430077d85c9473c27eef4e6ac5a0325b0050c0cedc3c47c8b010c06eeff39075aaaac5555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8b010c06eefd21840aaaab2aaaaabcaaaaaaf2aaaaabcaaaaaaf2aaaaabcaaaaaaf2aaaaabc8b"
+
+const GPSL1DATA = [
+    uint4000"0x8baaa8beae7de8c0e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae7bd1c0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae79c94064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae77b6479aaaaa5555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8beae75aec500000a1f02d85ffffffffd7bc9904a35103943ee7972a0f43ab7fffff208baaa8beae73ee80e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae71d800100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae6fc74064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae6db307753509edab6e87b1abdfd6f2c2cb84d554e01250d045abb6b001394eab08baaa8beae6ba40510000960fd2789ffffff5a84366d2cdc02e9dc02f43b8b4b1557fffff208baaa8beae69ebc0e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae67d600100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae65ce8064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae63b54780502a400";
+    uint4000"0x0363bfb000597bb47cf7fffbe84159f0eaa123802f84aaaae48baaa8beae61adc520000c9f02d876000000a57bc992ddc3f44b58d5fcbd59d51bfffffffac8baaa8beae5fec40e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae5ddac0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae5bcdc064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae59b987aaaaafaaaaaa95555555aaaaaaa95555555aaaaaaa95555555aaaaaaa308baaa8beae57aa4530000fe0fd27a00000000284366fb2ff3f47bc03b04ba9830d5ffffffac8baaa8beae55e580e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae53dc80100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae51c40064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae4fb787baaaacd55555435555550d55555435555550d55555435555550d55555108baaa8beae4daf05400007e0fd27a00000000284366fbde6fe89f29c092f53d5e088000008c8baaa8beae4bef40e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae49d9c0100c0660003861bf59b8e80864cfbccccc";
+    uint4000"0xc5010ca84df264bc510429fa48baaa8beae47ca0064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae45be479aaaaa5555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8beae43a9455000049f02d876000000a57bc992d07616852504bee725d55928000008c8baaa8beae41e680e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae3fddc0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae3dc54064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae3bbe87caaaa4d55555435555550d55555435555550d55555435555550d55555108baaa8beae39a60560000160fd2789ffffff5a84366d223fe926d292add278574958000008c8baaa8beae37e280e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae35d400100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae33c30064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae31b747daaaa7aaaaaa95555555aaaaaaa95555555aaaaaaa95555555aaaaaaa308baaa8beae2fa8057000021f02d85ffffffffd7bc99044d4f1329d5c2342408582a7fffff20";
+    uint4000"0x8baaa8beae2de7c0e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae2bdec0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae29c64064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae27b947eaaaa25555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8beae25a1c5800001e0fd27a00000000284366fb0625b42397c620ca2066007fffff208baaa8beae23e180e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae21d700100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae1fc1c064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae1db587f4444e11111127bbbbbb611111127bbbbbb61110600800000000003faac8baaa8beae1ba28737c3aafffffffffffffffffffffffffffffffffffffffffffffd5f81b448baaa8beae19ed40e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae17d080100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae15c80064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae13b3c79aaaaa555";
+    uint4000"0x5556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8beae11ab4410000e60fd2789ffffff5a84366d225edcce4c3e450be054ca6ffffffac8baaa8beae0fe340e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae0dd5c0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae0bc2c064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beae09b68593333460eae9066b60003284366fbbb0e45fcc85ce66da87fc28e5568388baaa8beae07a54420000b9f02d876000000a57bc992d08b38141ba5466bb610b4f000000008baaa8beae05ea80e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beae03d380100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beae01cb0064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadffb985a0000760fd2789ffffff5a84366d24f3c05009db4c31d15f1708000008c8baaa8beadfda104300008e0fd27a00000000284366fb376afe489109d15c4ac2bc000000008baaa8beadfbe140e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beadf9d7c0100c0660003861bf59b8e80864cfbccccc";
+    uint4000"0xc5010ca84df264bc510429fa48baaa8beadf7c40064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadf5b045b000041f02d85ffffffffd7bc9904756325ad0d196e36e8d469ffffffac8baaa8beadf3a744400000e0fd27a00000000284366fb07f24c07b2dd92942841497fffff208baaa8beadf1e880e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beadefd9c0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beadedc14064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadebba85c0000c1f02d85ffffffffd7bc9904a3a7f642b0bd25d7a022198000008c8baaa8beade9a2045000039f02d876000000a57bc992d61688c0f2cf334aad7ba53000000008baaa8beade7e680e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beade5d000100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beade3c70064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beade1b3479aaaaa5555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8beaddfa58460000660fd2789ffffff5a84366d2cb4c615cee6ef3ea234cee7fffff20";
+    uint4000"0x8baaa8beadddea40e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beaddbd340100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beadd9cbc064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadd7b4c5d0000f60fd2789ffffff5a84366d2ce1586d4daf213f23afb1d000000008baaa8beadd5ac447000051f02d85ffffffffd7bc990477c9494e2389001002f5757fffff208baaa8beadd3ec00e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beadd1da80100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beadcfc5c064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadcdb185e0000a9f02d876000000a57bc992d5f3d37f8e64fcd56867d257fffff208baaa8beadcba684800006e0fd27a00000000284366fb85d8d4f9e518ecf1b7c9e0ffffffac8baaa8beadc9e940e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beadc7d480100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beadc5cc0064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadc3b7c5f00009e0f";
+    uint4000"0xd27a00000000284366fb88525db4c29054efcd433a7fffff208baaa8beadc1af449000059f02d876000000a57bc992d89a21fcf1227270da0f7db000000008baaa8beadbfed40e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beadbddbc0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beadbbccc064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadb9b8840aaaab2aaaaabcaaaaaaf2aaaaabcaaaaaaf2aaaaabcaaaaaaf2aaaaabc8baaa8beadb7ab44a0000060fd2789ffffff5a84366d2237670279fb570b92fe353000000008baaa8beadb5e480e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beadb3dd80100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8beadb1c50064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beadafb6879aaaaa5555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8beadadae04b000031f02d85ffffffffd7bc9904ef5e76106f7c610fa2ff558000008c8baaa8beadabee40e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8beada9d8c0100c0660003861bf59b8e80864cfbccccc";
+    uint4000"0xc5010ca84df264bc510429fa48baaa8beada7cb0064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8beada5bf47eaaaa25555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8beada3a844c0000b1f02d85ffffffffd7bc9904a2a212ac8475d9607982d7000000008baaa8beada1e780e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8bead9fdf40100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8bead9dc7c064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8bead9bbc074aaaaf2aaaaabcaaaaaaf2aaaaabcaaaaaaf2aaaaabcaaaaaaf2aaaaabc8baaa8bead99a484d0000860fd2789ffffff5a84366d24f51fb18f5784639a56b80000000008baaa8bead97e000e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8bead95d680100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8bead93c18064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8bead91b5c75aaaac5555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8bead8faa84e0000d9f02d876000000a57bc992db1722e05562a3efaa9dd528000008c";
+    uint4000"0x8baaa8bead8de540e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8bead8bdc40100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8bead89c4c064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8bead87bbc76aaaa9aaaaaa95555555aaaaaaa95555555aaaaaaa95555555aaaaaaa308baaa8bead85a344f0000ee0fd27a00000000284366fbb370e85c78ed4199607d507fffff208baaa8bead83e300e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8bead81d580100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8bead7fc98064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8bead7dbdc79aaaaa5555556aaaaaaa55555556aaaaaaa55555556aaaaaaa55555559c8baaa8bead7baac500000a1f02d85ffffffffd7bc9904a35103943ee7972a0f43ab7fffff208baaa8bead79e500e9000f75555540aaaaaaf2aaaaabcaaaa0257fafbd4593dc273ffb9e8f48baaa8bead77d8c0100c0660003861bf59b8e80864cfbcccccc5010ca84df264bc510429fa48baaa8bead75c04064b410c9688d79f79cd40d52e77cdff5f32eba317a7ff29406c004370148baaa8bead73bb87753509eda";
+]
+
 
 @testset "GPS L1 constructor" begin
     gpsl1 = GPSL1()
@@ -104,80 +116,152 @@ end
 end
 
 @testset "GPS L1 test data decoding" begin
-    decoder = GPSL1DecoderState(1)
+    decoder = GPSL1DecoderState(25)
 
+    e_values       = zeros(31); e_values[25] = 0.006249904632568359
+    t_oa_values    = fill(0x000000000007c000, 31)
+    δi_values      = fill(0.017455023574651885, 31); δi_values[25] = 0.12939966841558787
+    Ω_dot_values   = zeros(31); Ω_dot_values[25] = 3.141616575226232e-7
+    sv_healths     = fill("00000000", 31)
+    sqrt_A_values  = fill(5153.70068359375, 31)
+    Ω_0_values     = [ 0.9309151162826294,-0.21355963682751117,-1.3601612153513243, -0.19503614470114108,
+                      -2.3907618634107664,-1.2934929722028254,  2.939997392795146,   2.9980856799254663,
+                       2.90515588043202,   0.8703842943137864, -0.40818644534672865,-2.2915688083761583,
+                       1.9468114948902273, 1.92800450094344,    1.8790392050223226, -2.2747965111140833,
+                      -1.2333033261367568, 0.8775070434848794, -1.1769426399279497,  0.8237562967562418,
+                      -0.1811449300077196, 0.8834358642497763,  1.897445476448837,  -0.15087727198112835,
+                       1.6921463411443713, 1.9447060163771674,  2.881117397807016,  -2.266460359171323,
+                      -1.2251210965826247,-2.3375200717335782,  2.9373462575418645]
+    ω_values       = [-1.2019776857552396, 2.714100745441627,   0.8899440473874415,  0.4732911216521067,
+                       1.2949861317246272,-1.463009084475038,   2.923551291154714,   2.976520067208277,
+                       1.459411195454233,  0.5908353955800706,  0.6840685457664337, -0.8127667625180299,
+                       1.5061837527246984,-2.0994983848320645, -0.7419976674097294, -0.38597817856898975,
+                      -2.7500264556516596,-2.4382575937528643, -0.39128456865286465, 1.3146076784579506,
+                      -2.6488990718159213,-1.82339682329378,    2.8824027059281154, -0.6395231817932232,
+                      -1.2294114490987422, 0.9676722320954713, -1.6511730252070136, -2.057136771340827,
+                      -1.3434334844256162, 1.4131749322482823, -1.1938287873266253]
+    M_0_values     = [ 0.7772687393343071, 1.8146314862965967,  1.4561147845912032,  -1.6325469181548915,
+                      -2.025272215345597, -2.302044518971553,  -0.004539025182903811,-0.6746275980902107,
+                      -0.9311753986672926, 2.675434018291522,  -0.14266433285067617,  0.18639551854437897,
+                       2.4951422152942526, 2.095625233145465,   2.600880155155299,   -2.332779561769453,
+                       2.86441326082409,  -2.204820247384678,   2.1227365459376077,  -2.0576318696322295,
+                      -0.9285714512995756, 2.953611472287631,   1.5835962280078775,  -2.3064959095098363,
+                      -0.9196229803655571, 1.1444365533932548, -2.7133509823709856,  -2.994534978790226,
+                      -0.8758738183344963,-2.562498053346696,  -0.07783042512675355]
+    af0_values     = zeros(31); af0_values[25] = 0.00043487548828125
+    af1_values     = zeros(31); af1_values[25] = 2.4920154828578234e-9
+    prns = [5; 16; 20; 12; 24; 28; 30; 17; 8; 1; 23; 22; 19; 6; 11; 31; 9; 14; 3; 29; 7; 25; 4; 13; 21; 2; 27; 18; 26; 10; 15]
+    test_almanac_data = Dict(
+        prn => (
+            e = e_values[prn],
+            t_oa = t_oa_values[prn],
+            δi = δi_values[prn],
+            Ω_dot = Ω_dot_values[prn],
+            sv_health = sv_healths[prn],
+            sqrt_A = sqrt_A_values[prn],
+            Ω_0 = Ω_0_values[prn],
+            ω = ω_values[prn],
+            M_0 = M_0_values[prn],
+            af0 = af0_values[prn],
+            af1 = af1_values[prn],
+        ) for prn in prns
+    )
     test_data = GNSSDecoder.GPSL1Data(;
-        last_subframe_id = 5,
+        last_subframe_id = 3,
         integrity_status_flag = false,
-        TOW = 34945 * 6,
+        TOW = 43333 * 6,
         alert_flag = false,
-        anti_spoof_flag = true,
-        trans_week = 67,
+        anti_spoof_flag = false,
+        trans_week = 58,
         codeonl2 = 1,
         ura = 2.0,
         svhealth = "000000",
-        IODC = "0001001000",
+        IODC = "0000000001",
         l2pcode = false,
-        T_GD = -1.0710209608078003e-8,
-        t_0c = 216000,
-        a_f2 = 0.0,
-        a_f1 = -4.774847184307873e-12,
-        a_f0 = -0.00018549291417002678,
-        IODE_Sub_2 = "01001000",
-        C_rs = 70.65625,
-        Δn = 3.930878022562108e-9,
-        M_0 = 2.4393048719362045,
-        C_uc = 3.604218363761902e-6,
-        e = 0.01144192845094949,
-        C_us = 1.3023614883422852e-5,
-        sqrt_A = 5153.7995529174805,
-        t_0e = 216000,
+        T_GD = 9.313225746154785e-10,
+        t_0c = 266400,
+        a_f2 = 2.9976021664879227e-15,
+        a_f1 = 1.0431904229335487e-9,
+        a_f0 = 8.355360478162766e-6,
+        IODE_Sub_2 = "00000001",
+        C_rs = 6,
+        Δn = 1.1702987476403108e-8,
+        M_0 = 0.7425089733705321,
+        C_uc = 1.000240445137024e-6,
+        e = 0.09999999997671694,
+        C_us = 2.000480890274048e-6,
+        sqrt_A = 5153.700811386108,
+        t_0e = 266400,
         fit_interval = false,
         AODO = 31,
-        C_ic = -1.73225998878479e-7,
-        Ω_0 = 0.0600607702978756,
-        C_is = -2.2351741790771484e-7,
-        i_0 = 0.9781895349147778,
-        C_rc = 136.34375,
-        ω = 0.635978551768012,
-        Ω_dot = -7.383521839035659e-9,
-        IODE_Sub_3 = "01001000",
-        i_dot = -3.4465721349922174e-10,
+        C_ic = 3.0007213354110718e-6,
+        Ω_0 = 1.6162756322990954,
+        C_is = 3.999099135398865e-6,
+        i_0 = 1.0717994640412103,
+        C_rc = 5,
+        ω = -1.2294114827458582,
+        Ω_dot = 3.1415915741848384e-7,
+        IODE_Sub_3 = "00000001",
+        i_dot = 3.142988060925545e-10,
+        α_0 = 4.6566128730773926e-9,
+        α_1 = 1.4901161193847656e-8,
+        α_2 = -5.960464477539063e-8,
+        α_3 = -5.960464477539063e-8,
+        β_0 = 79872.0,
+        β_1 = 65536.0,
+        β_2 = -65536.0,
+        β_3 = -393216.0,
+        A_0 = 0.00024970434606075287,
+        A_1 = 1.000000082740371e-9,
+        Δt_LS = 18,
+        t_ot = 507904,
+        WN_t = 58,
+        WN_LSF = 56,
+        DN = 2,
+        Δt_LSF = 18,
+        sv_config = [4*ones(31); 1],
+        sv_health_sf4_25 = [repeat(["000000"], 7); "111111"],
+        almanac = test_almanac_data,
+        sv_health_sf5_25 = repeat(["000000"], 24),
+        t_oa = 507904,
+        WN_a = 58,
     )
 
-    state = decode(decoder, GPSL1DATA, 1508)
-    @test state.data == test_data
+    state = reduce((dec, data) -> decode(dec, data, sizeof(data)*8), GPSL1DATA, init=decoder)
+    @test all(field -> getfield(state.data, field) == getfield(test_data, field), fieldnames(GNSSDecoder.GPSL1Data))
     @test is_sat_healthy(state) == true
 
-    state = decode(decoder, ~GPSL1DATA, 1508)
-    @test state.data == test_data
+    state = reduce((dec, data) -> decode(dec, ~data, sizeof(data)*8), GPSL1DATA, init=decoder)
+    @test all(field -> getfield(state.data, field) == getfield(test_data, field), fieldnames(GNSSDecoder.GPSL1Data))
     @test is_sat_healthy(state) == true
 
     # test confirm_data
+    max_vote = 1
+    state = GNSSDecoder.confirm_data(state, max_vote)
     state = GNSSDecoder.GNSSDecoderState(
         state;
         raw_data = GNSSDecoder.GPSL1Data(state.data, C_ic = state.data.C_ic+1)
     )
-    state = GNSSDecoder.confirm_data(state)
+    state = GNSSDecoder.confirm_data(state, max_vote)
     @test state.data.C_ic == test_data.C_ic # erroneous data not accepted
     state = GNSSDecoder.GNSSDecoderState(
         state;
         raw_data = GNSSDecoder.GPSL1Data(state.data, C_ic = state.data.C_ic+1)
     )
-    state = GNSSDecoder.confirm_data(state)
+    state = GNSSDecoder.confirm_data(state, max_vote)
     @test state.data.C_ic == test_data.C_ic # erroneous data not accepted
     state = GNSSDecoder.GNSSDecoderState(
         state;
         raw_data = GNSSDecoder.GPSL1Data(state.data, C_ic = state.data.C_ic+1)
     )
-    state = GNSSDecoder.confirm_data(state)
+    state = GNSSDecoder.confirm_data(state, max_vote)
     @test state.data.C_ic == test_data.C_ic+1 # erroneous data accepted as it has been provided more often than true data
 end
 
 @testset "confirm_data branches" begin
     # Setup: create a base state with valid data
     decoder = GPSL1DecoderState(1)
-    state = decode(decoder, GPSL1DATA, 1508)
+    state = reduce((dec, data) -> decode(dec, data, sizeof(data)*8), GPSL1DATA, init=decoder)
     base_data = state.data
 
     # Branch 1: New IODC (not in cache) and empty data - should use data immediately
@@ -323,7 +407,7 @@ end
 
 @testset "GPS L1 reset_decoder_state" begin
     decoder = GPSL1DecoderState(1)
-    state = decode(decoder, GPSL1DATA, 1508)
+    state = reduce((dec, data) -> decode(dec, data, sizeof(data)*8), GPSL1DATA, init=decoder)
 
     # test reset_decoder_state
     state = reset_decoder_state(state)


### PR DESCRIPTION
I asked Claude to implement the decoding of subframes 4 and 5 based on [Interface Specification (IS-GPS-200N, 01 Aug 2022)](https://www.navcen.uscg.gov/sites/default/files/pdf/gps/IS-GPS-200N.pdf)
And this is what I got ;)
I open this as a draft, because I don't yet have a good way to test it.

Add support for decoding the remaining GPS LNAV subframes:

Subframe 4:
- Page 18: Ionospheric parameters (α0-α3, β0-β3) and UTC parameters (A0, A1, ΔtLS, tot, WNt, WNLSF, DN, ΔtLSF)
- Page 25: SV configurations/A-S flags for all 32 SVs and health status for SV 25-32
- Pages 2-5, 7-10: Almanac data for SV 25-32

Subframe 5:
- Pages 1-24: Almanac data for SV 1-24
- Page 25: SV health for SV 1-24 and almanac reference time/week

Almanac data includes: eccentricity, toa, δi, Ω_dot, sv_health, sqrt_A, Ω_0, ω, M_0, af0, and af1.