### PR TITLE
Store GPS L1 almanac entries in GPSL1Almanac struct

### DIFF
--- a/src/gpsl1.jl
+++ b/src/gpsl1.jl
@@ -38,6 +38,47 @@ Base.@kwdef struct GPSL1Constants <: AbstractGNSSConstants
 end
 
 """
+    GPSL1Almanac
+
+Almanac data for one GPS satellite, decoded from a single LNAV almanac page
+(subframe 4 pages 2-5 / 7-10 for SV 25-32, subframe 5 pages 1-24 for SV 1-24).
+
+The almanac provides reduced-precision orbital and clock parameters for satellite
+acquisition planning and bootstrapping position fixes. Inclination is broadcast as a
+delta from the nominal GPS constellation value (`i_nominal = 0.3 semi-circles ≈ 54°`),
+which the decoder stores in `δi`.
+
+# Fields
+- `e::Float64`: Eccentricity (dimensionless)
+- `t_oa::Int`: Almanac reference time of week (seconds)
+- `δi::Float64`: Inclination delta from nominal 0.3 semi-circles (rad)
+- `Ω_dot::Float64`: Rate of right ascension (rad/s)
+- `sv_health::String`: 8-bit SV health status (binary string; "00000000" = healthy)
+- `sqrt_A::Float64`: Square root of semi-major axis (√m)
+- `Ω_0::Float64`: Longitude of ascending node at weekly epoch (rad)
+- `ω::Float64`: Argument of perigee (rad)
+- `M_0::Float64`: Mean anomaly at reference time (rad)
+- `af0::Float64`: SV clock bias correction coefficient (seconds)
+- `af1::Float64`: SV clock drift correction coefficient (s/s)
+
+# Reference
+IS-GPS-200N, Section 20.3.3.5.1.2, Table 20-VI
+"""
+Base.@kwdef struct GPSL1Almanac
+    e::Union{Nothing,Float64} = nothing
+    t_oa::Union{Nothing,Int} = nothing
+    δi::Union{Nothing,Float64} = nothing
+    Ω_dot::Union{Nothing,Float64} = nothing
+    sv_health::Union{Nothing,String} = nothing
+    sqrt_A::Union{Nothing,Float64} = nothing
+    Ω_0::Union{Nothing,Float64} = nothing
+    ω::Union{Nothing,Float64} = nothing
+    M_0::Union{Nothing,Float64} = nothing
+    af0::Union{Nothing,Float64} = nothing
+    af1::Union{Nothing,Float64} = nothing
+end
+
+"""
     GPSL1Data
 
 Decoded GPS L1 C/A LNAV navigation message data.
@@ -160,7 +201,7 @@ Base.@kwdef struct GPSL1Data <: AbstractGNSSData
     sv_health_sf4_25::Union{Nothing,Vector{String}} = nothing
 
     # Subframe 5 pages 1-24: Almanac data (stored per SV ID)
-    almanac::Union{Nothing,Dictionary{Int64,NamedTuple}} = nothing
+    almanac::Union{Nothing,Dictionary{Int64,GPSL1Almanac}} = nothing
 
     # Subframe 5 page 25: SV health for SV 1-24 (6-bit health words)
     sv_health_sf5_25::Union{Nothing,Vector{String}} = nothing
@@ -1108,7 +1149,7 @@ function decode_almanac_page(state::GNSSDecoderState{<:GPSL1Data}, sv_id::Int)
 
     # Decode almanac parameters
     alm_e = get_bits(word3_comp, 30, 9, 16) / 1 << 21
-    alm_toa = get_bits(word4_comp, 30, 1, 8) << 12
+    alm_toa = Int(get_bits(word4_comp, 30, 1, 8) << 12)
     alm_δi = get_twos_complement_num(word4_comp, 30, 9, 16) * state.constants.PI / 1 << 19
     alm_Ω_dot = get_twos_complement_num(word5_comp, 30, 1, 16) * state.constants.PI / 1 << 38
     alm_sv_health = bitstring(get_bits(word5_comp, 30, 17, 8))[end-7:end]
@@ -1125,7 +1166,7 @@ function decode_almanac_page(state::GNSSDecoderState{<:GPSL1Data}, sv_id::Int)
     alm_af1 = get_twos_complement_num(word10_comp, 30, 9, 11) / 1 << 38
 
     # Store almanac data for this SV
-    almanac_entry = (
+    almanac_entry = GPSL1Almanac(;
         e = alm_e,
         t_oa = alm_toa,
         δi = alm_δi,
@@ -1139,7 +1180,7 @@ function decode_almanac_page(state::GNSSDecoderState{<:GPSL1Data}, sv_id::Int)
         af1 = alm_af1,
     )
 
-    almanac = something(state.raw_data.almanac, Dictionary{Int64,NamedTuple}())
+    almanac = something(state.raw_data.almanac, Dictionary{Int64,GPSL1Almanac}())
     set!(almanac, sv_id, almanac_entry)
     state = GNSSDecoderState(state; raw_data = GPSL1Data(state.raw_data; almanac))
 

--- a/test/gpsl1.jl
+++ b/test/gpsl1.jl
@@ -119,7 +119,7 @@ end
     decoder = GPSL1DecoderState(25)
 
     e_values       = zeros(31); e_values[25] = 0.006249904632568359
-    t_oa_values    = fill(0x000000000007c000, 31)
+    t_oa_values    = fill(507904, 31)
     δi_values      = fill(0.017455023574651885, 31); δi_values[25] = 0.12939966841558787
     Ω_dot_values   = zeros(31); Ω_dot_values[25] = 3.141616575226232e-7
     sv_healths     = fill("00000000", 31)
@@ -154,10 +154,10 @@ end
     # Dictionary (subframe-4 pages 2-5, 7-10 interleaved with subframe-5
     # pages 1-24). Dictionaries.jl `==` is order-sensitive.
     prns = [16, 17, 18, 19, 20, 21, 22, 23, 24, 1, 25, 2, 26, 3, 27, 4, 28, 5, 6, 29, 7, 30, 8, 31, 9, 10, 11, 12, 13, 14, 15]
-    test_almanac_data = Dictionary{Int64,NamedTuple}(
+    test_almanac_data = Dictionary{Int64,GNSSDecoder.GPSL1Almanac}(
         prns,
         [
-            (
+            GNSSDecoder.GPSL1Almanac(;
                 e = e_values[prn],
                 t_oa = t_oa_values[prn],
                 δi = δi_values[prn],


### PR DESCRIPTION
## Summary
- Introduce `Base.@kwdef struct GPSL1Almanac` and swap the GPS L1 almanac value type from `NamedTuple` to `GPSL1Almanac` (stored inside the existing `Dictionary{Int64,…}` introduced in #30).
- Flip `t_oa` to `Int` with an `Int(...)` cast at the decode site so the value reads as a time-of-week scalar (`507904`) rather than `0x000000000007c000`. This matches the existing top-level `t_oa::Int64` on `GPSL1Data`.

## Why
PR #28 introduces a typed `GalileoAlmanac` struct for the Galileo I/NAV decoder. Aligning GPS L1 with the same shape (typed struct, full docstring, named fields) makes the cross-system API consistent and gives users a named type they can dispatch on / pattern-match against.

The container (`Dictionary{Int64, …}`) is unchanged — this PR only swaps the value type from `NamedTuple` to `GPSL1Almanac`.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 116/116 pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)