### PR TITLE
feat(galileo)!: Galileo E1B on AFF3CT ConvViterbiDecoder + soft-symbol API (issue #37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
   `GPSL1CAConstants`, `GPSL1DecoderState` → `GPSL1CADecoderState`. The
   corresponding `GPSL1Almanac` / `VotedGPSL1Data` / `GPSL1Cache` renamed
   to the `*CA*` variants in step.
+* **galileo:** Galileo E1B is now decoded from `Float32` soft symbols
+  end-to-end. The K=7 NSC convolutional FEC is undone with AFF3CT.jl's
+  `ConvViterbiDecoder` (`poly = [0o171, 0o133]`, K=114, N=240) instead of
+  ViterbiDecoder.jl, and the `ViterbiDecoder` and `CRC` dependencies are
+  dropped. Closes #37.
 
 ### Features
 
@@ -21,9 +26,15 @@
   `syncro_sequence_length + preamble_length` per signal (308 for GPS
   L1 C/A; 260 for Galileo E1B).
 * **layout:** source tree reorganised — `src/gpsl1.jl` → `src/gps/l1ca.jl`,
-  `src/galileo_e1b.jl` → `src/galileo/e1b.jl`. Galileo's hard-bit
-  internals are unchanged in this slice; the soft-input migration of the
-  E1B Viterbi step is tracked in #37.
+  `src/galileo_e1b.jl` → `src/galileo/e1b.jl`.
+* **galileo:** Galileo E1B's `decode_syncro_sequence` reads the 240
+  polarity-corrected `Float32` LLR soft symbols directly from the deque
+  (sync hook hard-slices the tail only for the 10-bit page-sync preamble
+  bit-pattern check). The 30×8 block deinterleave and "invert every second
+  bit" steps now operate on soft symbols (inversion = negation), and the
+  page parser, even/odd caching, and WT7→WT10 almanac chaining are
+  unchanged. The inline `galCRC24` const is removed in favour of the shared
+  `crc24q` (issue #36).
 * **gpsl1c:** new GPS L1C-D (CNAV-2) decoder — TOI frame sync plus full
   subframe-2 parsing. `GPSL1C_DDecoderState(prn)` wires up a 1852-symbol
   soft buffer, the BCH(51,8) TOI codeword table for frame sync

--- a/Project.toml
+++ b/Project.toml
@@ -6,25 +6,21 @@ version = "2.0.0"
 [deps]
 Aff3ct = "529ff742-b572-47ff-bc84-d3f557f53d2b"
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
-CRC = "44b605c4-b955-5f2b-9b6d-d2bd01d3d205"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 GNSSSignals = "52c80523-2a4e-5c38-8979-05588f836870"
-ViterbiDecoder = "5f0870c7-49c9-4542-b5f1-5d9ed4caea51"
 
 [compat]
 Aff3ct = "1"
 Aqua = "0.8"
 BitIntegers = "0.2.6, 0.3.5"
-CRC = "4"
 DataStructures = "0.18"
 Dictionaries = "0.4"
 DocStringExtensions = "0.6, 0.7, 0.8, 0.9"
 GNSSSignals = "2.2"
 Random = "1"
 Test = "1"
-ViterbiDecoder = "0.1.0"
 julia = "1.10"
 
 [extras]

--- a/src/GNSSDecoder.jl
+++ b/src/GNSSDecoder.jl
@@ -1,7 +1,8 @@
 module GNSSDecoder
 
 using DocStringExtensions,
-    GNSSSignals, BitIntegers, ViterbiDecoder, CRC, Dictionaries, DataStructures
+    GNSSSignals, BitIntegers, Dictionaries, DataStructures
+import Aff3ct
 
 export decode,
     GPSL1CADecoderState,
@@ -16,20 +17,19 @@ export decode,
 export crc24q, BCH_TOI_CODEWORDS, BCHToiSync, sync_bch_toi, pack_hard_codeword,
        soft_to_hard_codeword, deinterleave!, interleave!
 
-const galCRC24 = crc(spec(24, 0x864cfb, 0x000000, false, false, 0x000000, 0xcde703))
-
 include("gnss.jl")
 include("bit_fiddling.jl")
-include("gps/l1ca.jl")
-include("galileo/e1b.jl")
 
-# New deep-module utilities (issue #36). These are signal-independent and
-# carry their own unit tests under `test/`. The existing `galCRC24` above
-# is *not* migrated here — issue #37 will switch Galileo to consume
-# `crc24q` directly, after issue #35's framework refactor lands.
+# Signal-independent deep-module utilities (issue #36). These carry their own
+# unit tests under `test/`. They are included before the per-signal decoders
+# because Galileo E1B (issue #37) consumes `crc24q` and `deinterleave!`
+# directly.
 include("crc.jl")
 include("bch_toi.jl")
 include("deinterleave.jl")
+
+include("gps/l1ca.jl")
+include("galileo/e1b.jl")
 
 # GPS L1C-D (CNAV-2) decoder (issue #38). Included after the shared utilities
 # above because it consumes `crc24q`, `sync_bch_toi`, the BCH TOI table, and

--- a/src/crc.jl
+++ b/src/crc.jl
@@ -8,10 +8,10 @@
 # IS-GPS-800G §3.5.3.5, IS-GPS-200N §3.5.3.5.
 #
 # The CRC field appears at the end of the message, so a correctly received
-# message satisfies `crc24q(whole_message_with_crc) == 0`. The legacy inline
-# implementation in `src/GNSSDecoder.jl` (`galCRC24`, built from the `CRC`
-# package) is preserved for now — issue #37 (Galileo soft-input migration)
-# will switch Galileo to consume `crc24q` directly.
+# message satisfies `crc24q(whole_message_with_crc) == 0`. This replaced the
+# legacy inline `galCRC24` (built from the `CRC` package) when Galileo E1B
+# migrated to the soft-symbol decode path in issue #37; the `CRC` dependency
+# is no longer required.
 
 const CRC24Q_POLY = UInt32(0x01864cfb)
 const CRC24Q_MASK = UInt32(0x00ffffff)

--- a/src/galileo/e1b.jl
+++ b/src/galileo/e1b.jl
@@ -1,7 +1,19 @@
-# UInt288 buffer for Galileo E1B
-# which holds at least a complete Galileo E1B page
-# plus 10 extra syncronization bits
+# UInt288 buffer for Galileo E1B sync — holds the 260-symbol page window
+# (250 syncro + 10 preamble) hard-sliced for the bit-pattern preamble check.
 BitIntegers.@define_integers 288
+
+# Galileo E1B uses the rate-1/2, constraint-length-7 (K=7) non-systematic
+# convolutional (NSC) FEC with generator polynomials G1 = 0o171, G2 = 0o133
+# (Galileo OS SIS ICD, Issue 2.2, §4.1.4). After the 30×8 block deinterleave a
+# page carries 240 encoded symbols which the Viterbi decoder maps back to 120
+# trellis steps: 114 information bits + 6 tail bits. AFF3CT's `ConvViterbiDecoder`
+# is configured with K = 114, N = 240 and the same polynomials; it applies the
+# trellis termination internally and returns exactly the 114 information bits
+# (the 6 tail bits are consumed by termination and never surface), which is
+# precisely the per-page payload the I/NAV parser expects.
+const GALILEO_E1B_VITERBI_K = 114
+const GALILEO_E1B_VITERBI_N = 240
+const GALILEO_E1B_VITERBI_POLY = [0o171, 0o133]
 
 """
     GalileoE1BConstants
@@ -217,14 +229,15 @@ Holds the soft-symbol `CircularDeque{Float32}` (capacity = 250 + 10 = 260),
 the cached even-page bits used to stitch two consecutive pages into a word, and
 the two-position almanac-chain state needed to merge word types 7-10. Soft-symbol
 buffering is shared across all signals; the rest is Galileo-specific. The
-transient `UInt288` packed-bit buffer used for sync is not stored here — it is
-computed as a local value and threaded through the decode path (see
-`pack_buffer`).
+transient `UInt288` packed-bit buffer used for the page-sync preamble check is
+not stored here — it is computed as a local value and threaded through the
+decode path (see `pack_buffer`).
 
-The Galileo decoder still consumes *hard-decision bits* internally in this
-slice — the soft-symbol migration to AFF3CT.jl's Viterbi is tracked in #37.
-The deque-backed input boundary is the same as L1 C/A so the public API is
-uniform.
+The Galileo decoder consumes *soft symbols* end-to-end: the page-sync hook
+hard-slices the deque tail only for the 10-bit preamble bit-pattern match,
+while the K=7 NSC FEC is undone on the raw `Float32` LLRs via AFF3CT.jl's
+`ConvViterbiDecoder` (issue #37). The deque-backed input boundary is identical
+to L1 C/A so the public API is uniform.
 
 # Fields
 $(TYPEDFIELDS)
@@ -716,14 +729,61 @@ end
 
 packed_buffer_type(::GNSSDecoderState{<:GalileoE1BData}) = UInt288
 
+"""
+    galileo_e1b_viterbi(soft_page) -> UInt128
+
+Recover one I/NAV page's 114-bit payload from its `soft_page` — the 240
+polarity-corrected `Float32` LLR soft symbols of a Galileo E1B page (the
+`syncro_sequence_length - preamble_length` encoded symbols between the leading
+and trailing page-sync preambles).
+
+The transmit FEC chain (Galileo OS SIS ICD, Issue 2.2, §4.1.4) is undone in
+order on the soft symbols:
+
+1. **30×8 block deinterleave** of the 240 LLRs (`deinterleave!` from `src/deinterleave.jl`).
+2. **Invert every second symbol** — the spec inverts the G2 output of the rate-1/2
+   encoder. On soft symbols an inversion is a sign flip (negation), so confidence
+   magnitudes are preserved.
+3. **K=7 NSC Viterbi** via AFF3CT.jl's `ConvViterbiDecoder`. AFF3CT's LLR sign
+   convention matches ours (positive ⇒ bit 0), so the LLRs feed in directly. The
+   decoder returns the 114 information bits (the 6 tail bits are consumed by
+   trellis termination).
+
+The 114 decoded bits are packed MSB-first into the low bits of a `UInt128`,
+matching the legacy hard-bit `parse(UInt128, ...; base = 2)` layout the parser
+consumes.
+"""
+function galileo_e1b_viterbi(soft_page::AbstractVector{Float32})
+    deinterleaved = deinterleave(soft_page, 30, 8)
+    @inbounds for i in 2:2:length(deinterleaved)
+        deinterleaved[i] = -deinterleaved[i]
+    end
+    dec = Aff3ct.ConvViterbiDecoder(
+        GALILEO_E1B_VITERBI_K,
+        GALILEO_E1B_VITERBI_N,
+        GALILEO_E1B_VITERBI_POLY,
+    )
+    info_bits = Aff3ct.decode(dec, deinterleaved)
+    bits = UInt128(0)
+    @inbounds for b in info_bits
+        bits = (bits << 1) | UInt128(b)
+    end
+    return bits
+end
+
 function decode_syncro_sequence(state::GNSSDecoderState{<:GalileoE1BData}, buffer)
-    encoded_bits = bitstring(buffer >> state.constants.preamble_length)[sizeof(
-        buffer,
-    )*8-state.constants.syncro_sequence_length+state.constants.preamble_length+1:end]
-    deinterleaved_encoded_bits = deinterleave(encoded_bits, 30, 8)
-    inv_deinterleaved_encoded_bits = invert_every_second_bit(deinterleaved_encoded_bits)
-    decoded_bits = viterbi_decode(7, [79, 109], inv_deinterleaved_encoded_bits)
-    bits = parse(UInt128, decoded_bits; base = 2)
+    # The 240 encoded symbols are the soft-buffer entries between the leading
+    # 10-bit page-sync preamble and the trailing preamble of the next page
+    # (deque indices preamble_length+1 .. syncro_sequence_length). Resolve the
+    # 180-degree polarity ambiguity by negating the LLRs when the sync hook
+    # flagged the page as inverted (an inverted soft symbol = a negated one).
+    deque = soft_buffer(state)
+    sign = state.is_shifted_by_180_degrees ? -1.0f0 : 1.0f0
+    soft_page = Vector{Float32}(undef, GALILEO_E1B_VITERBI_N)
+    @inbounds for i in 1:GALILEO_E1B_VITERBI_N
+        soft_page[i] = sign * deque[state.constants.preamble_length + i]
+    end
+    bits = galileo_e1b_viterbi(soft_page)
     is_even = !get_bit(bits, 114, 1)
     is_nominal_page = !get_bit(bits, 114, 2)
     state = GNSSDecoderState(
@@ -747,7 +807,7 @@ function decode_syncro_sequence(state::GNSSDecoderState{<:GalileoE1BData}, buffe
             get_bits(bits, 114, 3, 16)
         bits_to_check_CRC =
             UInt288(state.cache.even_page_part_bits) << 106 + get_bits(bits, 114, 1, 106)
-        if galCRC24(reverse(digits(UInt8, bits_to_check_CRC; base = 256))) == 0
+        if crc24q(reverse(digits(UInt8, bits_to_check_CRC; base = 256))) == 0
             data_type = get_bits(data, 128, 1, 6)
             if data_type == 0
                 if get_bits(data, 128, 7, 2) == 2 # '10'

--- a/test/bit_fiddling.jl
+++ b/test/bit_fiddling.jl
@@ -31,5 +31,11 @@
           ex_inv_deinterleaved_bits
 
     ex_true_bits = "111111111111000011001100101010100000000000001111001100110101010111100011111011001101111110001010000111000001001101000000"
-    @test viterbi_decode(7, [79, 109], ex_inv_deinterleaved_bits) == ex_true_bits[1:114]
+    # The K=7 NSC Viterbi step is now AFF3CT.jl's ConvViterbiDecoder fed with
+    # ±1 soft LLRs ('0' ⇒ +1, '1' ⇒ -1; positive ⇒ bit 0). It returns the 114
+    # information bits (the 6 tail bits are absorbed by trellis termination).
+    soft = Float32[c == '1' ? -1.0f0 : 1.0f0 for c in ex_inv_deinterleaved_bits]
+    dec = Aff3ct.ConvViterbiDecoder(114, 240, [0o171, 0o133])
+    decoded = join(string.(Int.(Aff3ct.decode(dec, soft))))
+    @test decoded == ex_true_bits[1:114]
 end

--- a/test/crc.jl
+++ b/test/crc.jl
@@ -59,14 +59,18 @@ using GNSSDecoder: crc24q
         end
     end
 
-    @testset "Cross-check against legacy galCRC24" begin
-        # The new `crc24q` must produce bit-identical results to the
-        # legacy `CRC.jl`-based `galCRC24` for any byte stream. This
-        # pins the migration path for issue #37.
-        for raw in (UInt8.(collect("123456789")),
-                    UInt8[0x55, 0xaa, 0xff, 0x00, 0x12, 0x34],
-                    UInt8[i for i in 0x00:0x20])
-            @test crc24q(raw) == UInt32(GNSSDecoder.galCRC24(raw))
+    @testset "Frozen golden values (legacy galCRC24 parity)" begin
+        # `crc24q` replaced the legacy `CRC.jl`-based `galCRC24` when Galileo
+        # E1B migrated to the soft-symbol decode path (issue #37). These golden
+        # values were captured from `galCRC24` before its removal, so they pin
+        # bit-identical behaviour across the migration. The "123456789" entry
+        # is the canonical CRC-24Q check value (0xCDE703).
+        for (raw, expected) in (
+            (UInt8.(collect("123456789")),            UInt32(0x00cde703)),
+            (UInt8[0x55, 0xaa, 0xff, 0x00, 0x12, 0x34], UInt32(0x005126f1)),
+            (UInt8[i for i in 0x00:0x20],              UInt32(0x00bf660c)),
+        )
+            @test crc24q(raw) == expected
         end
     end
 end

--- a/test/galileo_e1b.jl
+++ b/test/galileo_e1b.jl
@@ -139,9 +139,9 @@ end
     )
 
     # Convert the hard-bit chunks to ±1.0f0 soft symbols at the test boundary.
-    # Galileo's decoder still consumes hard bits internally in this slice; the
-    # boundary conversion mirrors how Tracking.jl v2 callers will feed soft
-    # prompts.
+    # The golden fixture was captured as hard bits; the boundary conversion
+    # mirrors how Tracking.jl v2 callers feed soft prompts into the soft-symbol
+    # decode path (AFF3CT Viterbi, issue #37).
     state = reduce(
         (dec, data) -> decode(dec, to_soft_symbols(data, sizeof(data) * 8), sizeof(data) * 8),
         GALILEO_E1B_DATA;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
-using Test, GNSSDecoder, BitIntegers, ViterbiDecoder, GNSSSignals
+using Test, GNSSDecoder, BitIntegers, GNSSSignals
 using Aqua
 using Dictionaries
+import Aff3ct
 
 BitIntegers.@define_integers 4000
 
@@ -25,8 +26,9 @@ end
 
 @testset "GNSSDecoder.jl" begin
     @testset "Aqua" begin
-        # Aff3ct is now referenced from `src/gps/l1c_d.jl` (issue #38), so it
-        # is no longer a stale dependency.
+        # Aff3ct is referenced from `src/` (Galileo E1B's K=7 NSC Viterbi,
+        # issue #37, and the GPS L1C-D LDPC decoders, issue #38), so it
+        # needs no stale-dep exemption.
         Aqua.test_all(GNSSDecoder)
     end
 


### PR DESCRIPTION
## Summary

Migrates Galileo E1B (`src/galileo/e1b.jl`) to the v2 soft-symbol decode API delivered in #35 and replaces ViterbiDecoder.jl with AFF3CT.jl's `ConvViterbiDecoder` for the K=7 NSC step. Closes #37.

The Galileo decoder keeps the same field set, page-sync preamble (`0101100000`), even/odd page caching, word-type-dispatched parser, and WT7→WT10 almanac chaining. Only the input shape and the Viterbi step change:

- **Input shape.** The decoder is fed `Float32` soft symbols. The sync hook hard-slices the deque tail only for the 10-bit page-sync preamble bit-pattern match (no soft correlation). Buffer length stays 260 (250 syncro + 10 preamble).
- **Viterbi step.** After a sync hit, the 240 polarity-corrected `Float32` LLRs (deque indices `preamble_length+1 .. syncro_sequence_length`) are deinterleaved (30×8, via the shared `deinterleave!`), every second symbol negated ("invert every second bit" on soft symbols = a sign flip), then fed to `Aff3ct.ConvViterbiDecoder(114, 240, [0o171, 0o133])`. 180° polarity is resolved by negating the LLRs when the sync hook flags the page inverted. AFF3CT's LLR convention (positive ⇒ bit 0) matches ours, so the LLRs feed in directly. The decoded 114 info bits are packed MSB-first into a `UInt128`, exactly the layout the existing page parser consumes — so the parser is reused unchanged.
- **CRC.** The inline `galCRC24` const in `src/GNSSDecoder.jl` is removed; Galileo now consumes the shared `crc24q` from `src/crc.jl` (#36).
- **Dependencies.** `ViterbiDecoder` and `CRC` are dropped from `Project.toml`. `BitIntegers` stays (UInt288 sync buffer for Galileo, UInt320 for GPS, plus the test fixtures). `Aff3ct` comes off the Aqua `stale_deps` ignore list now that it is used from `src/`.

### Tail-bit / termination handling (K=7, 6 tail bits)

The rate-1/2 K=7 NSC code uses 6 tail bits: the 240 encoded symbols decode to a 120-step trellis = 114 information bits + 6 tail bits. AFF3CT's `ConvViterbiDecoder` applies the trellis termination internally and returns **exactly the 114 information bits** — the 6 tail bits are consumed by termination and never surface in `V_K`. This was verified against the legacy `viterbi_decode(7, [79, 109], …)` path, which also returned 114 bits; the two produce bit-identical output on the golden fixture (`[79, 109]` and `[0o171, 0o133]` are the bit-reversed polynomial conventions of the two libraries).

## Test evidence

Full suite green on Julia 1.12:

```
Test Summary:  | Pass  Total
GNSSDecoder.jl | 1407   1407
```

- Galileo E1B golden-fixture regression passes byte-for-byte in **both** normal and inverted (`is_shifted_by_180_degrees`) polarity, plus the `reset_decoder_state` test.
- Aqua.jl clean (no stale-dep exemption needed).
- `test/bit_fiddling.jl` FEC-chain spec example now drives the AFF3CT decoder; `test/crc.jl` swaps the `galCRC24` cross-check for frozen golden CRC-24Q values captured before removal (incl. the canonical `"123456789"` → `0xCDE703`).

## Caveats / decisions

- A fresh `ConvViterbiDecoder` is constructed per page inside `galileo_e1b_viterbi` (once per decoded page) rather than cached in the immutable state cache — keeps `==` semantics simple and the allocation is negligible at I/NAV page rate.
- The `decode_syncro_sequence(state, buffer)` `buffer` argument (the hard-sliced packed sync buffer) is now unused by the Galileo path — polarity is taken from `state.is_shifted_by_180_degrees` — but the parameter is kept to honour the framework method contract.
- The legacy `String`-based `deinterleave` / `invert_every_second_bit` helpers in `src/bit_fiddling.jl` are retained: they are no longer used by `src/` but still have unit coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)