### PR TITLE
chore: remove gated recording test and dead String helpers; document L1C-D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,9 +90,17 @@
   polarities; PRN 2 cross-checks satellite-specific ephemeris against
   the midi-almanac entry decoded from PRN 1's stream and requires the
   constellation-wide subframe-3 broadcast to decode identically from
-  both satellites. The full-recording test (all 31 channels, GSS-CNAVDATA
-  container parsing, fixture provenance byte-compare) stays gated behind
-  `GPS_L1C_D_FIXTURE_DIR`.
+  both satellites. The previous env-var-gated full-recording test
+  (`GPS_L1C_D_FIXTURE_DIR`) is removed: it never ran in CI, the fixture
+  provenance byte-compare against the source recording was verified
+  once at extraction time, and all 31 channels share the decode path
+  the two committed PRNs already cover.
+* **cleanup:** remove the dead `String`-based `deinterleave` and
+  `invert_every_second_bit` helpers left over from the hard-bit era —
+  Galileo E1B now runs the shared `Float32` deinterleaver and negation;
+  the Galileo-ICD example test drives the same soft path the decoder
+  uses. Documentation (README, manual index) updated to list GPS L1C-D
+  and the soft-symbol input convention.
 
 ### Internal
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@
 [![codecov](https://codecov.io/gh/JuliaGNSS/GNSSDecoder.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaGNSS/GNSSDecoder.jl)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Decodes various GNSS satellite signals.
+Decodes various GNSS satellite signals from soft symbols (`Float32`,
+positive ⇒ bit 0, negative ⇒ bit 1, magnitude ⇒ confidence) as produced by
+a tracking loop such as `Tracking.jl`.
 
 Currently implemented:
- * GPS L1
- * Galileo E1B
+ * GPS L1 C/A (LNAV)
+ * GPS L1C-D (CNAV-2)
+ * Galileo E1B (I/NAV)
 
 ## Installation
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,6 +5,7 @@ A Julia package for decoding GNSS (Global Navigation Satellite System) navigatio
 ## Supported Systems
 
 - **GPS L1 C/A**: Decodes the 50 bps LNAV data stream from GPS L1 civil signals
+- **GPS L1C-D**: Decodes the 100 sps CNAV-2 data stream from the modernized GPS L1C signal's data component
 - **Galileo E1B**: Decodes the 250 bps I/NAV data stream from Galileo E1B Open Service signals
 
 ## Installation
@@ -79,6 +80,30 @@ julia> state.prn
 
 julia> typeof(state)
 GNSSDecoderState{GNSSDecoder.GalileoE1BData, GNSSDecoder.GalileoE1BConstants, GNSSDecoder.GalileoE1BCache}
+
+julia> state = decode(state, Float32[+1, -1, +1, +1, -1, -1, -1, -1, -1, +1], 10);  # Decode 10 soft symbols
+
+julia> GNSSDecoder.num_bits_buffered(state)
+10
+```
+
+### GPS L1C-D Decoding
+
+The GPS L1C-D (CNAV-2) decoder synchronises on the BCH-encoded TOI counter
+(no fixed preamble), LDPC-decodes subframes 2 and 3, and validates each with
+CRC-24Q. Construction loads the LDPC parity-check matrices shipped with the
+package:
+
+```jldoctest l1cd_example
+julia> using GNSSDecoder
+
+julia> state = GPSL1C_DDecoderState(1);  # Initialize decoder for PRN 1
+
+julia> state.prn
+1
+
+julia> typeof(state)
+GNSSDecoderState{GPSL1C_DData, GNSSDecoder.GPSL1C_DConstants, GNSSDecoder.GPSL1C_DCache}
 
 julia> state = decode(state, Float32[+1, -1, +1, +1, -1, -1, -1, -1, -1, +1], 10);  # Decode 10 soft symbols
 
@@ -161,3 +186,19 @@ Similar ephemeris and clock parameters are available for Galileo, plus:
 | `data_validity_status_e1b` | Data validity status |
 | `broadcast_group_delay_e1_e5a` | E1-E5a group delay |
 | `broadcast_group_delay_e1_e5b` | E1-E5b group delay |
+
+### GPS L1C-D Data
+
+CNAV-2 clock-and-ephemeris data plus the subframe-3 page payloads — see
+[`GPSL1C_DData`](@ref) for the full field list:
+
+| Field | Description |
+|-------|-------------|
+| `toi`, `ITOW`, `WN` | Time of interval, interval time of week, week number |
+| `t_0e`, `ΔA`, `e`, `M_0`, `ω`, `Ω_0`, `i_0`, … | Clock and ephemeris (CED) parameters |
+| `α0..α3`, `β0..β3` | Klobuchar ionospheric coefficients (subframe-3 page 1) |
+| `A0_UTC`, `Δt_LS`, … | UTC parameters (page 1) |
+| `A0_GGTO`, `t_GGTO`, … | GPS/GNSS time offset and EOP (page 2) |
+| `reduced_almanacs`, `midi_almanacs` | Per-SV almanac dictionaries (pages 3/4) |
+| `differential_corrections` | Per-SV differential corrections (page 5) |
+| `text_message` | Broadcast text (page 6) |

--- a/src/bit_fiddling.jl
+++ b/src/bit_fiddling.jl
@@ -11,13 +11,3 @@ function get_twos_complement_num(word::Unsigned, word_length::Int, start::Int, l
     num_shift_bits = sizeof(value) * 8 - length
     signed(value << num_shift_bits) >> num_shift_bits
 end
-
-function deinterleave(bits::String, columns, rows)
-    String(vec(permutedims(reshape(collect(bits), columns, rows))))
-end
-
-function invert_every_second_bit(bits::String)
-    reshaped_bits = reshape(collect(bits), 2, length(bits) >> 1)
-    reshaped_bits[2, :] .= ifelse.(reshaped_bits[2, :] .== '1', '0', '1')
-    String(vec(reshaped_bits))
-end

--- a/test/bit_fiddling.jl
+++ b/test/bit_fiddling.jl
@@ -21,21 +21,28 @@
     @test GNSSDecoder.get_twos_complement_num(0b100, 3, 1, 3) == -4
     @test GNSSDecoder.get_twos_complement_num(0b101, 3, 1, 3) == -3
 
-    # examplary bits from Galileo specification
+    # Exemplary bits from the Galileo specification, run through the same
+    # soft-symbol FEC chain the E1B decoder uses: ±1 Float32 LLRs ('0' ⇒ +1,
+    # '1' ⇒ -1; positive ⇒ bit 0) → 30×8 block deinterleave → negate every
+    # second symbol → AFF3CT K=7 NSC Viterbi.
+    to_soft(s) = Float32[c == '1' ? -1.0f0 : 1.0f0 for c in s]
+    to_bits(v) = join(ifelse.(v .< 0, '1', '0'))
+
     ex_encoded_bits = "101000000101111110001100111100000101111010100000000110011110001110101000010100000100111101010111011110001000011011111010111001111001100000011111111000100000100111110110000010011100011101100000100101110100100011000110110110010000011100111010"
     ex_deinterleaved_bits = "100011000001101010101010011100110011000101011010011011110101100101111000100101010101010110001100110011101010010110010000101001101000010000000010000000100001101110011001111010110101110000011000101110111111110111111101111001000101001100100010"
-    @test GNSSDecoder.deinterleave(ex_encoded_bits, 30, 8) == ex_deinterleaved_bits
+    deinterleaved = GNSSDecoder.deinterleave(to_soft(ex_encoded_bits), 30, 8)
+    @test to_bits(deinterleaved) == ex_deinterleaved_bits
 
     ex_inv_deinterleaved_bits = "110110010100111111111111001001100110010000001111001110100000110000101101110000000000000011011001100110111111000011000101111100111101000101010111010101110100111011001100101111100000100101001101111011101010100010101000101100010000011001110111"
-    @test GNSSDecoder.invert_every_second_bit(ex_deinterleaved_bits) ==
-          ex_inv_deinterleaved_bits
+    # Inverting a hard bit is negating the soft symbol.
+    inverted = copy(deinterleaved)
+    inverted[2:2:end] .= -inverted[2:2:end]
+    @test to_bits(inverted) == ex_inv_deinterleaved_bits
 
     ex_true_bits = "111111111111000011001100101010100000000000001111001100110101010111100011111011001101111110001010000111000001001101000000"
-    # The K=7 NSC Viterbi step is now AFF3CT.jl's ConvViterbiDecoder fed with
-    # ±1 soft LLRs ('0' ⇒ +1, '1' ⇒ -1; positive ⇒ bit 0). It returns the 114
-    # information bits (the 6 tail bits are absorbed by trellis termination).
-    soft = Float32[c == '1' ? -1.0f0 : 1.0f0 for c in ex_inv_deinterleaved_bits]
+    # The K=7 NSC Viterbi step returns the 114 information bits (the 6 tail
+    # bits are absorbed by trellis termination).
     dec = Aff3ct.ConvViterbiDecoder(114, 240, [0o171, 0o133])
-    decoded = join(string.(Int.(Aff3ct.decode(dec, soft))))
+    decoded = join(string.(Int.(Aff3ct.decode(dec, inverted))))
     @test decoded == ex_true_bits[1:114]
 end

--- a/test/gps_l1c_d.jl
+++ b/test/gps_l1c_d.jl
@@ -652,46 +652,4 @@ end
         @test d2.text_message == d1.text_message
         @test d2.num_sf3_pages_received == 68
     end
-
-    # --- Optional full Spirent GSS-CNAVDATA recording (gated) ----------------
-    # Validates the committed fixture's provenance: parses the original
-    # simulator output, demultiplexes the same channel, and requires it to be
-    # byte-identical to `test/data/gps_l1c_d_prn1_symbols.bin` before running
-    # the same golden assertions.
-    @testset "Spirent GSS-CNAVDATA recording (gated)" begin
-        fixture_dir = get(ENV, "GPS_L1C_D_FIXTURE_DIR", nothing)
-        if isnothing(fixture_dir)
-            @info "GPS_L1C_D_FIXTURE_DIR not set — skipping full Spirent recording test"
-            @test true
-        else
-            symfile = joinpath(fixture_dir, "nav_data_fec.L1_cnv")
-            @test isfile(symfile)
-            raw = read(symfile)
-            @test String(raw[1:12]) == "GSS CNAVDATA"
-            @test raw[15] == 0x02  # file type: post-FEC symbols
-            body = raw[17:end]
-            @test length(body) % 225 == 0
-            blocks = [body[(i-1)*225+1:i*225] for i in 1:length(body)÷225]
-            # Channel count = number of consecutive blocks sharing the
-            # 52-symbol (7-byte) subframe-1 prefix of the first epoch (all
-            # satellites broadcast the same TOI, so the prefix only changes
-            # at an epoch boundary).
-            nch = findfirst(i -> blocks[i][1:7] != blocks[1][1:7], 1:length(blocks))
-            nch = isnothing(nch) ? 1 : nch - 1
-            channel = parse(Int, get(ENV, "GPS_L1C_D_FIXTURE_CHANNEL", "0"))
-            prn = parse(Int, get(ENV, "GPS_L1C_D_FIXTURE_PRN", "1"))
-            packed = reduce(vcat, blocks[(1+channel):nch:end])
-            # The committed fixtures must be byte-identical to the channels
-            # they were extracted from.
-            for (fixture_channel, fname) in
-                ((0, "gps_l1c_d_prn1_symbols.bin"), (1, "gps_l1c_d_prn2_symbols.bin"))
-                @test reduce(vcat, blocks[(1+fixture_channel):nch:end]) ==
-                      read(joinpath(@__DIR__, "data", fname))
-            end
-            soft = Float32[(b >> (7 - j)) & 0x01 == 0 ? 1.0f0 : -1.0f0
-                           for b in packed for j in 0:7]
-            state = decode(GPSL1C_DDecoderState(prn), soft, length(soft))
-            assert_spirent_golden(state)
-        end
-    end
 end


### PR DESCRIPTION
## Summary

Cleanup pass over the v2 transition:

- **Remove the `GPS_L1C_D_FIXTURE_DIR`-gated testset** — it never ran in CI, its provenance byte-compare (committed fixtures vs source recording channels) was verified once at extraction time, and the two committed PRN fixtures exercise the decode path shared by all 31 recorded channels.
- **Remove dead `String`-based `deinterleave` / `invert_every_second_bit`** from `src/bit_fiddling.jl` — unused since Galileo E1B moved to the shared `Float32` deinterleaver in #37. The Galileo-ICD example test now drives the exact soft-symbol chain the decoder uses (±1 LLRs → 30×8 deinterleave → negate every second symbol → AFF3CT Viterbi).
- **Docs**: README and the manual index now list GPS L1C-D (CNAV-2) alongside L1 C/A and E1B, with a quick-start doctest and a data-field overview; README states the soft-symbol input convention. (`api.md` already covered the L1C-D types.)

## Test evidence

1589 / 1589 pass; Documenter build + doctests clean.

Part of #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)