### PR TITLE
refactor(gpsl1c): unify bit-field extraction on BitIntegers (issue #48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,13 @@
   buffer from `state.cache.complemented_buffer[]` instead of
   `state.buffer`; everything downstream of that read (deinterleave,
   Viterbi, page parser) is byte-for-byte unchanged.
+* GPS L1C-D now parses its subframe fields from packed BitIntegers words
+  (subframe 2: `UInt600`; subframe 3: the existing `UInt288`) via the
+  shared `get_bits` / `get_twos_complement_num` / `get_bit` helpers,
+  unifying bit-field extraction with the GPS L1 C/A and Galileo E1B
+  decoders. The private `Vector{Bool}` `_u` / `_s` helpers are removed; the
+  LDPC info block is CRC-checked on the bit vector and then packed MSB-first
+  for parsing. Decoded data is byte-for-byte unchanged ([#48](https://github.com/JuliaGNSS/GNSSDecoder.jl/issues/48)).
 
 # [1.3.0](https://github.com/JuliaGNSS/GNSSDecoder.jl/compare/v1.2.0...v1.3.0) (2026-06-03)
 

--- a/src/gps/l1c_d.jl
+++ b/src/gps/l1c_d.jl
@@ -42,6 +42,17 @@ const L1C_D_SF2_INFO_BITS = 600
 const L1C_D_SF3_INFO_BITS = 274
 const L1C_D_CRC_BITS = 24
 
+# Packed-word types for bit-field extraction. After the LDPC decode + CRC check
+# the info bits are packed MSB-first (LSB = last bit) into a wide integer and
+# parsed with the shared `get_bits`/`get_twos_complement_num`/`get_bit` helpers
+# (src/bit_fiddling.jl), matching the GPS L1 C/A and Galileo E1B decoders (#48).
+#
+# SF2's 600 info bits need a dedicated `UInt600`. SF3's 274 info bits reuse the
+# `UInt288` already defined for Galileo E1B (galileo/e1b.jl is included before
+# this file): `get_bits(word, 274, …)` addresses the 274 logical bits regardless
+# of the wider storage as long as they are right-aligned.
+BitIntegers.@define_integers 600
+
 # Semi-major axis reference (IS-GPS-800G Table 3.5-1 footnote, meters).
 const L1C_D_A_REF = 26_559_710.0
 # Rate-of-right-ascension reference (IS-GPS-800G Table 3.5-1, semi-circles/sec).
@@ -808,8 +819,12 @@ function decode_syncro_sequence(state::GNSSDecoderState{<:GPSL1C_DData}, sync::B
     return state
 end
 
-"Run an Aff3ct LDPC BP decode on `symbols` and return the `info_bits`-long info block as a `Vector{Bool}` (true = 1)."
-function ldpc_decode_bits(decoder::LDPCBPDecoder, symbols, info_bits::Int)
+# Run an Aff3ct LDPC BP decode, CRC-check the info block, and pack it MSB-first
+# into a wide word for the shared `get_bits` helpers. CRC failure ⇒ `nothing`
+# (the caller silently drops the subframe). `T` is the packed-word type holding
+# the `info_bits`-long block (`UInt600` for SF2, `UInt288` for SF3).
+"Decode, CRC-check, and pack one LDPC info block into a `T`-typed word; `nothing` on CRC failure."
+function ldpc_decode_word(decoder::LDPCBPDecoder, symbols, info_bits::Int, ::Type{T}) where {T}
     # AFF3CT LLR convention matches ours: positive ⇒ bit 0, negative ⇒ bit 1.
     llr = collect(Float32, symbols)
     info = Aff3ct.decode(decoder, llr)
@@ -817,72 +832,68 @@ function ldpc_decode_bits(decoder::LDPCBPDecoder, symbols, info_bits::Int)
     @inbounds for i in 1:info_bits
         bits[i] = info[i] != 0
     end
-    return bits
-end
-
-"Verify a CRC-24Q-protected info block (message bits followed by a 24-bit CRC). Returns true iff the CRC matches."
-function crc24q_ok(info_bits::AbstractVector{Bool})
-    crc24q(info_bits) == 0
+    # CRC-24Q over the whole info block (message bits + trailing 24-bit CRC) is
+    # 0 iff the checksum matches; check on the bit vector before packing.
+    crc24q(bits) == 0 || return nothing
+    # Pack MSB-first so bit 1 is the most-significant bit and bit `info_bits`
+    # the least-significant (right-aligned), matching `word_length = info_bits`.
+    word = T(0)
+    @inbounds for b in bits
+        word = (word << 1) | T(b ? 1 : 0)
+    end
+    return word
 end
 
 # ---- Subframe 2 bit-field extraction (IS-GPS-800G Figure 3.5-1) ------------
 #
-# `bits` is the 600-bit subframe-2 info block, MSB first, 1-based. Helpers
-# below read fields by their 1-based start bit and length.
-
-"Read an unsigned integer field of `len` bits starting at 1-based bit `start` (MSB first)."
-function _u(bits::AbstractVector{Bool}, start::Int, len::Int)
-    v = 0
-    @inbounds for i in 0:(len - 1)
-        v = (v << 1) | (bits[start + i] ? 1 : 0)
-    end
-    return v
-end
-
-"Read a two's-complement signed integer field of `len` bits starting at 1-based bit `start`."
-function _s(bits::AbstractVector{Bool}, start::Int, len::Int)
-    v = _u(bits, start, len)
-    (bits[start] ? v - (1 << len) : v)
-end
+# `word` is the 600-bit subframe-2 info block packed MSB-first into a `UInt600`
+# (bit 1 = MSB). Fields are read by 1-based start bit and length through the
+# shared `get_bits` / `get_twos_complement_num` / `get_bit` helpers.
 
 function decode_subframe2(state::GNSSDecoderState{<:GPSL1C_DData}, sf2_symbols)
-    bits = ldpc_decode_bits(state.cache.sf2_decoder, sf2_symbols, L1C_D_SF2_INFO_BITS)
-    crc24q_ok(bits) || return state  # silently drop on CRC failure
+    word = ldpc_decode_word(
+        state.cache.sf2_decoder,
+        sf2_symbols,
+        L1C_D_SF2_INFO_BITS,
+        UInt600,
+    )
+    isnothing(word) && return state  # silently drop on CRC failure
+    N = L1C_D_SF2_INFO_BITS
 
     PI = state.constants.PI
 
-    WN = _u(bits, 1, 13)
-    ITOW = _u(bits, 14, 8)
-    t_op = _u(bits, 22, 11) * 300
-    l1c_health = bits[33]
-    ura_ed_index = _s(bits, 34, 5)
-    t_0e = _u(bits, 39, 11) * 300
-    ΔA = _s(bits, 50, 26) * 2.0^-9
-    A_dot = _s(bits, 76, 25) * 2.0^-21
-    Δn_0 = _s(bits, 101, 17) * 2.0^-44 * PI
-    Δn_0_dot = _s(bits, 118, 23) * 2.0^-57 * PI
-    M_0 = _s(bits, 141, 33) * 2.0^-32 * PI
-    e = _u(bits, 174, 33) * 2.0^-34
-    ω = _s(bits, 207, 33) * 2.0^-32 * PI
-    Ω_0 = _s(bits, 240, 33) * 2.0^-32 * PI
-    i_0 = _s(bits, 273, 33) * 2.0^-32 * PI
-    ΔΩ_dot = _s(bits, 306, 17) * 2.0^-44 * PI
-    i_0_dot = _s(bits, 323, 15) * 2.0^-44 * PI
-    C_is = _s(bits, 338, 16) * 2.0^-30
-    C_ic = _s(bits, 354, 16) * 2.0^-30
-    C_rs = _s(bits, 370, 24) * 2.0^-8
-    C_rc = _s(bits, 394, 24) * 2.0^-8
-    C_us = _s(bits, 418, 21) * 2.0^-30
-    C_uc = _s(bits, 439, 21) * 2.0^-30
-    ura_ned0_index = _s(bits, 460, 5)
-    ura_ned1_index = _u(bits, 465, 3)
-    ura_ned2_index = _u(bits, 468, 3)
-    a_f0 = _s(bits, 471, 26) * 2.0^-35
-    a_f1 = _s(bits, 497, 20) * 2.0^-48
-    a_f2 = _s(bits, 517, 10) * 2.0^-60
-    T_GD = _s(bits, 527, 13) * 2.0^-35
-    ISC_L1CP = _s(bits, 540, 13) * 2.0^-35
-    ISC_L1CD = _s(bits, 553, 13) * 2.0^-35
+    WN = Int(get_bits(word, N, 1, 13))
+    ITOW = Int(get_bits(word, N, 14, 8))
+    t_op = Int(get_bits(word, N, 22, 11)) * 300
+    l1c_health = get_bit(word, N, 33)
+    ura_ed_index = get_twos_complement_num(word, N, 34, 5)
+    t_0e = Int(get_bits(word, N, 39, 11)) * 300
+    ΔA = get_twos_complement_num(word, N, 50, 26) * 2.0^-9
+    A_dot = get_twos_complement_num(word, N, 76, 25) * 2.0^-21
+    Δn_0 = get_twos_complement_num(word, N, 101, 17) * 2.0^-44 * PI
+    Δn_0_dot = get_twos_complement_num(word, N, 118, 23) * 2.0^-57 * PI
+    M_0 = get_twos_complement_num(word, N, 141, 33) * 2.0^-32 * PI
+    e = Int(get_bits(word, N, 174, 33)) * 2.0^-34
+    ω = get_twos_complement_num(word, N, 207, 33) * 2.0^-32 * PI
+    Ω_0 = get_twos_complement_num(word, N, 240, 33) * 2.0^-32 * PI
+    i_0 = get_twos_complement_num(word, N, 273, 33) * 2.0^-32 * PI
+    ΔΩ_dot = get_twos_complement_num(word, N, 306, 17) * 2.0^-44 * PI
+    i_0_dot = get_twos_complement_num(word, N, 323, 15) * 2.0^-44 * PI
+    C_is = get_twos_complement_num(word, N, 338, 16) * 2.0^-30
+    C_ic = get_twos_complement_num(word, N, 354, 16) * 2.0^-30
+    C_rs = get_twos_complement_num(word, N, 370, 24) * 2.0^-8
+    C_rc = get_twos_complement_num(word, N, 394, 24) * 2.0^-8
+    C_us = get_twos_complement_num(word, N, 418, 21) * 2.0^-30
+    C_uc = get_twos_complement_num(word, N, 439, 21) * 2.0^-30
+    ura_ned0_index = get_twos_complement_num(word, N, 460, 5)
+    ura_ned1_index = Int(get_bits(word, N, 465, 3))
+    ura_ned2_index = Int(get_bits(word, N, 468, 3))
+    a_f0 = get_twos_complement_num(word, N, 471, 26) * 2.0^-35
+    a_f1 = get_twos_complement_num(word, N, 497, 20) * 2.0^-48
+    a_f2 = get_twos_complement_num(word, N, 517, 10) * 2.0^-60
+    T_GD = get_twos_complement_num(word, N, 527, 13) * 2.0^-35
+    ISC_L1CP = get_twos_complement_num(word, N, 540, 13) * 2.0^-35
+    ISC_L1CD = get_twos_complement_num(word, N, 553, 13) * 2.0^-35
 
     raw = GPSL1C_DData(
         state.raw_data;
@@ -927,10 +938,12 @@ end
 #
 # Every SF3 page is a 274-bit info block: bits 1-8 are the transmitting PRN,
 # bits 9-14 the 6-bit page number, then page-specific fields, with the trailing
-# 24 bits a CRC-24Q. After the CRC passes we dispatch on the page number and
-# merge the parsed fields into `raw_data` immutably (same style as SF2). The
-# IRN-IS-800J figures are implemented: page 1 carries the four ISC fields that
-# pre-IRN-J recordings lack, so older recordings are out of scope.
+# 24 bits a CRC-24Q. After the CRC passes the 274 bits are packed MSB-first into
+# a `UInt288` (`get_bits(word, 274, …)` addresses the right-aligned 274 logical
+# bits); we dispatch on the page number and merge the parsed fields into
+# `raw_data` immutably (same style as SF2). The IRN-IS-800J figures are
+# implemented: page 1 carries the four ISC fields that pre-IRN-J recordings
+# lack, so older recordings are out of scope.
 
 "Insert/overwrite `value` keyed by `key` in a (possibly `nothing`) `Dictionary`, returning the updated copy."
 function _merge_keyed(dict::Union{Nothing,Dictionary{Int,V}}, key::Int, value::V) where {V}
@@ -940,8 +953,13 @@ function _merge_keyed(dict::Union{Nothing,Dictionary{Int,V}}, key::Int, value::V
 end
 
 function decode_subframe3(state::GNSSDecoderState{<:GPSL1C_DData}, sf3_symbols)
-    bits = ldpc_decode_bits(state.cache.sf3_decoder, sf3_symbols, L1C_D_SF3_INFO_BITS)
-    crc24q_ok(bits) || return state  # silently drop on CRC failure
+    word = ldpc_decode_word(
+        state.cache.sf3_decoder,
+        sf3_symbols,
+        L1C_D_SF3_INFO_BITS,
+        UInt288,
+    )
+    isnothing(word) && return state  # silently drop on CRC failure
 
     # CRC-valid page received: count it, then dispatch on the page number.
     raw = GPSL1C_DData(
@@ -949,19 +967,20 @@ function decode_subframe3(state::GNSSDecoderState{<:GPSL1C_DData}, sf3_symbols)
         num_sf3_pages_received = state.raw_data.num_sf3_pages_received + 1,
     )
 
-    page = _u(bits, 9, 6)  # bits 1-8 PRN, bits 9-14 page number (IS-GPS-800J §3.5.4)
+    N = L1C_D_SF3_INFO_BITS
+    page = Int(get_bits(word, N, 9, 6))  # bits 1-8 PRN, bits 9-14 page (IS-GPS-800J §3.5.4)
     raw = if page == L1C_D_SF3_PAGE_UTC_IONO
-        parse_sf3_page1(raw, bits, state.constants.PI)
+        parse_sf3_page1(raw, word, state.constants.PI)
     elseif page == L1C_D_SF3_PAGE_GGTO_EOP
-        parse_sf3_page2(raw, bits, state.constants.PI)
+        parse_sf3_page2(raw, word, state.constants.PI)
     elseif page == L1C_D_SF3_PAGE_REDUCED_ALMANAC
-        parse_sf3_page3(raw, bits, state.constants.PI)
+        parse_sf3_page3(raw, word, state.constants.PI)
     elseif page == L1C_D_SF3_PAGE_MIDI_ALMANAC
-        parse_sf3_page4(raw, bits, state.constants.PI)
+        parse_sf3_page4(raw, word, state.constants.PI)
     elseif page == L1C_D_SF3_PAGE_DIFF_CORRECTION
-        parse_sf3_page5(raw, bits, state.constants.PI)
+        parse_sf3_page5(raw, word, state.constants.PI)
     elseif page == L1C_D_SF3_PAGE_TEXT
-        parse_sf3_page6(raw, bits)
+        parse_sf3_page6(raw, word)
     else
         raw  # unsupported/reserved page (e.g. 7 SV-config, 8 ISM): counted, ignored
     end
@@ -970,90 +989,94 @@ function decode_subframe3(state::GNSSDecoderState{<:GPSL1C_DData}, sf3_symbols)
 end
 
 "Subframe 3, page 1 — UTC + Klobuchar iono + ISC (IS-GPS-800J Fig 3.5-2, Table 3.5-3)."
-function parse_sf3_page1(raw::GPSL1C_DData, bits::AbstractVector{Bool}, PI::Float64)
+function parse_sf3_page1(raw::GPSL1C_DData, word::UInt288, PI::Float64)
+    N = L1C_D_SF3_INFO_BITS
     GPSL1C_DData(
         raw;
         # UTC polynomial (Table 3.5-3).
-        A0_UTC = _s(bits, 15, 16) * 2.0^-35,
-        A1_UTC = _s(bits, 31, 13) * 2.0^-51,
-        A2_UTC = _s(bits, 44, 7) * 2.0^-68,
-        Δt_LS = _s(bits, 51, 8),
-        t_ot = _u(bits, 59, 16) * 2^4,
-        WN_ot = _u(bits, 75, 13),
-        WN_LSF = _u(bits, 88, 13),
-        DN = _u(bits, 101, 4),
-        Δt_LSF = _s(bits, 105, 8),
+        A0_UTC = get_twos_complement_num(word, N, 15, 16) * 2.0^-35,
+        A1_UTC = get_twos_complement_num(word, N, 31, 13) * 2.0^-51,
+        A2_UTC = get_twos_complement_num(word, N, 44, 7) * 2.0^-68,
+        Δt_LS = get_twos_complement_num(word, N, 51, 8),
+        t_ot = Int(get_bits(word, N, 59, 16)) * 2^4,
+        WN_ot = Int(get_bits(word, N, 75, 13)),
+        WN_LSF = Int(get_bits(word, N, 88, 13)),
+        DN = Int(get_bits(word, N, 101, 4)),
+        Δt_LSF = get_twos_complement_num(word, N, 105, 8),
         # Klobuchar ionospheric coefficients (IS-GPS-200 Table 20-X; all 8-bit
         # two's-complement, scaled in seconds / seconds-per-semicircle^n).
-        α0 = _s(bits, 113, 8) * 2.0^-30,
-        α1 = _s(bits, 121, 8) * 2.0^-27,
-        α2 = _s(bits, 129, 8) * 2.0^-24,
-        α3 = _s(bits, 137, 8) * 2.0^-24,
-        β0 = _s(bits, 145, 8) * 2.0^11,
-        β1 = _s(bits, 153, 8) * 2.0^14,
-        β2 = _s(bits, 161, 8) * 2.0^16,
-        β3 = _s(bits, 169, 8) * 2.0^16,
+        α0 = get_twos_complement_num(word, N, 113, 8) * 2.0^-30,
+        α1 = get_twos_complement_num(word, N, 121, 8) * 2.0^-27,
+        α2 = get_twos_complement_num(word, N, 129, 8) * 2.0^-24,
+        α3 = get_twos_complement_num(word, N, 137, 8) * 2.0^-24,
+        β0 = get_twos_complement_num(word, N, 145, 8) * 2.0^11,
+        β1 = get_twos_complement_num(word, N, 153, 8) * 2.0^14,
+        β2 = get_twos_complement_num(word, N, 161, 8) * 2.0^16,
+        β3 = get_twos_complement_num(word, N, 169, 8) * 2.0^16,
         # Inter-signal corrections (Fig 3.5-2; 13-bit two's complement, 2^-35 s).
-        ISC_L1CA = _s(bits, 177, 13) * 2.0^-35,
-        ISC_L2C = _s(bits, 190, 13) * 2.0^-35,
-        ISC_L5I5 = _s(bits, 203, 13) * 2.0^-35,
-        ISC_L5Q5 = _s(bits, 216, 13) * 2.0^-35,
+        ISC_L1CA = get_twos_complement_num(word, N, 177, 13) * 2.0^-35,
+        ISC_L2C = get_twos_complement_num(word, N, 190, 13) * 2.0^-35,
+        ISC_L5I5 = get_twos_complement_num(word, N, 203, 13) * 2.0^-35,
+        ISC_L5Q5 = get_twos_complement_num(word, N, 216, 13) * 2.0^-35,
     )
 end
 
 "Subframe 3, page 2 — GGTO + EOP (IS-GPS-800J Fig 3.5-3, Tables 3.5-4/3.5-5)."
-function parse_sf3_page2(raw::GPSL1C_DData, bits::AbstractVector{Bool}, PI::Float64)
+function parse_sf3_page2(raw::GPSL1C_DData, word::UInt288, PI::Float64)
+    N = L1C_D_SF3_INFO_BITS
     GPSL1C_DData(
         raw;
         # GGTO (Table 3.5-4). Field order in Fig 3.5-3: tGGTO, WNGGTO, A0, A1, A2.
-        t_GGTO = _u(bits, 18, 16) * 2^4,
-        WN_GGTO = _u(bits, 34, 13),
-        A0_GGTO = _s(bits, 47, 16) * 2.0^-35,
-        A1_GGTO = _s(bits, 63, 13) * 2.0^-51,
-        A2_GGTO = _s(bits, 76, 7) * 2.0^-68,
-        GNSS_ID = _u(bits, 15, 3),
+        t_GGTO = Int(get_bits(word, N, 18, 16)) * 2^4,
+        WN_GGTO = Int(get_bits(word, N, 34, 13)),
+        A0_GGTO = get_twos_complement_num(word, N, 47, 16) * 2.0^-35,
+        A1_GGTO = get_twos_complement_num(word, N, 63, 13) * 2.0^-51,
+        A2_GGTO = get_twos_complement_num(word, N, 76, 7) * 2.0^-68,
+        GNSS_ID = Int(get_bits(word, N, 15, 3)),
         # EOP (Table 3.5-5). PM_X is split: 2 MSBs at bit 99, 19 LSBs at bit 101.
-        t_EOP = _u(bits, 83, 16) * 2^4,
-        PM_X = _s(bits, 99, 21) * 2.0^-20,
-        PM_X_dot = _s(bits, 120, 15) * 2.0^-21,
-        PM_Y = _s(bits, 135, 21) * 2.0^-20,
-        PM_Y_dot = _s(bits, 156, 15) * 2.0^-21,
-        ΔUT1 = _s(bits, 171, 31) * 2.0^-24,
-        ΔUT1_dot = _s(bits, 202, 19) * 2.0^-25,
+        t_EOP = Int(get_bits(word, N, 83, 16)) * 2^4,
+        PM_X = get_twos_complement_num(word, N, 99, 21) * 2.0^-20,
+        PM_X_dot = get_twos_complement_num(word, N, 120, 15) * 2.0^-21,
+        PM_Y = get_twos_complement_num(word, N, 135, 21) * 2.0^-20,
+        PM_Y_dot = get_twos_complement_num(word, N, 156, 15) * 2.0^-21,
+        ΔUT1 = get_twos_complement_num(word, N, 171, 31) * 2.0^-24,
+        ΔUT1_dot = get_twos_complement_num(word, N, 202, 19) * 2.0^-25,
     )
 end
 
 "Decode one 33-bit reduced-almanac packet starting at 1-based bit `start` (IS-GPS-800J Fig 3.5-9)."
 function _reduced_almanac_packet(
-    bits::AbstractVector{Bool},
+    word::UInt288,
     start::Int,
     WN_a::Int,
     t_oa::Int,
     PI::Float64,
 )
-    PRN_a = _u(bits, start, 8)
+    N = L1C_D_SF3_INFO_BITS
+    PRN_a = Int(get_bits(word, N, start, 8))
     PRN_a == 0 && return nothing  # empty packet ⇒ no further packets follow
     GPSL1C_DReducedAlmanac(;
         PRN_a,
         WN_a,
         t_oa,
-        δA = _s(bits, start + 8, 8) * 2.0^9,
-        Ω_0 = _s(bits, start + 16, 7) * 2.0^-6 * PI,
-        Φ_0 = _s(bits, start + 23, 7) * 2.0^-6 * PI,
-        l1_health = bits[start + 30],
-        l2_health = bits[start + 31],
-        l5_health = bits[start + 32],
+        δA = get_twos_complement_num(word, N, start + 8, 8) * 2.0^9,
+        Ω_0 = get_twos_complement_num(word, N, start + 16, 7) * 2.0^-6 * PI,
+        Φ_0 = get_twos_complement_num(word, N, start + 23, 7) * 2.0^-6 * PI,
+        l1_health = get_bit(word, N, start + 30),
+        l2_health = get_bit(word, N, start + 31),
+        l5_health = get_bit(word, N, start + 32),
     )
 end
 
 "Subframe 3, page 3 — six reduced-almanac packets (IS-GPS-800J Fig 3.5-4)."
-function parse_sf3_page3(raw::GPSL1C_DData, bits::AbstractVector{Bool}, PI::Float64)
-    WN_a = _u(bits, 15, 13)
-    t_oa = _u(bits, 28, 8) * 2^12
+function parse_sf3_page3(raw::GPSL1C_DData, word::UInt288, PI::Float64)
+    N = L1C_D_SF3_INFO_BITS
+    WN_a = Int(get_bits(word, N, 15, 13))
+    t_oa = Int(get_bits(word, N, 28, 8)) * 2^12
     almanacs = raw.reduced_almanacs
     # Six 33-bit packets at bits 36, 69, 102, 135, 168, 201.
     for start in (36, 69, 102, 135, 168, 201)
-        packet = _reduced_almanac_packet(bits, start, WN_a, t_oa, PI)
+        packet = _reduced_almanac_packet(word, start, WN_a, t_oa, PI)
         isnothing(packet) && break  # PRN_a==0 ⇒ remaining packets are filler
         almanacs = _merge_keyed(almanacs, packet.PRN_a, packet)
     end
@@ -1061,54 +1084,56 @@ function parse_sf3_page3(raw::GPSL1C_DData, bits::AbstractVector{Bool}, PI::Floa
 end
 
 "Subframe 3, page 4 — one Midi almanac (IS-GPS-800J Fig 3.5-5, Table 3.5-7)."
-function parse_sf3_page4(raw::GPSL1C_DData, bits::AbstractVector{Bool}, PI::Float64)
-    PRN_a = _u(bits, 36, 8)
+function parse_sf3_page4(raw::GPSL1C_DData, word::UInt288, PI::Float64)
+    N = L1C_D_SF3_INFO_BITS
+    PRN_a = Int(get_bits(word, N, 36, 8))
     PRN_a == 0 && return raw  # empty almanac
     alm = GPSL1C_DMidiAlmanac(;
         PRN_a,
-        WN_a = _u(bits, 15, 13),
-        t_oa = _u(bits, 28, 8) * 2^12,
-        l1_health = bits[44],
-        l2_health = bits[45],
-        l5_health = bits[46],
-        e = _u(bits, 47, 11) * 2.0^-16,
-        δi = _s(bits, 58, 11) * 2.0^-14 * PI,
-        Ω_dot = _s(bits, 69, 11) * 2.0^-33 * PI,
-        sqrt_A = _u(bits, 80, 17) * 2.0^-4,
-        Ω_0 = _s(bits, 97, 16) * 2.0^-15 * PI,
-        ω = _s(bits, 113, 16) * 2.0^-15 * PI,
-        M_0 = _s(bits, 129, 16) * 2.0^-15 * PI,
-        a_f0 = _s(bits, 145, 11) * 2.0^-20,
-        a_f1 = _s(bits, 156, 10) * 2.0^-37,
+        WN_a = Int(get_bits(word, N, 15, 13)),
+        t_oa = Int(get_bits(word, N, 28, 8)) * 2^12,
+        l1_health = get_bit(word, N, 44),
+        l2_health = get_bit(word, N, 45),
+        l5_health = get_bit(word, N, 46),
+        e = Int(get_bits(word, N, 47, 11)) * 2.0^-16,
+        δi = get_twos_complement_num(word, N, 58, 11) * 2.0^-14 * PI,
+        Ω_dot = get_twos_complement_num(word, N, 69, 11) * 2.0^-33 * PI,
+        sqrt_A = Int(get_bits(word, N, 80, 17)) * 2.0^-4,
+        Ω_0 = get_twos_complement_num(word, N, 97, 16) * 2.0^-15 * PI,
+        ω = get_twos_complement_num(word, N, 113, 16) * 2.0^-15 * PI,
+        M_0 = get_twos_complement_num(word, N, 129, 16) * 2.0^-15 * PI,
+        a_f0 = get_twos_complement_num(word, N, 145, 11) * 2.0^-20,
+        a_f1 = get_twos_complement_num(word, N, 156, 10) * 2.0^-37,
     )
     GPSL1C_DData(raw; midi_almanacs = _merge_keyed(raw.midi_almanacs, PRN_a, alm))
 end
 
 "Subframe 3, page 5 — one differential-correction packet (IS-GPS-800J Fig 3.5-6/3.5-10, Table 3.5-8)."
-function parse_sf3_page5(raw::GPSL1C_DData, bits::AbstractVector{Bool}, PI::Float64)
+function parse_sf3_page5(raw::GPSL1C_DData, word::UInt288, PI::Float64)
+    N = L1C_D_SF3_INFO_BITS
     # Page-level fields precede the 126-bit CDC+EDC packet. Layout (Fig 3.5-6):
     # bit 15 t_op-D (11, scale 300), bit 26 t_OD (11, scale 300),
     # bit 37 DC data type (1), then the CDC segment (bit 38) and EDC segment.
-    t_op_D = _u(bits, 15, 11) * 300
-    t_OD = _u(bits, 26, 11) * 300
-    dc_data_type = bits[37]
+    t_op_D = Int(get_bits(word, N, 15, 11)) * 300
+    t_OD = Int(get_bits(word, N, 26, 11)) * 300
+    dc_data_type = get_bit(word, N, 37)
     # CDC segment (Fig 3.5-10): PRN ID(8) δaf0(13) δaf1(8) UDRA(5) — starts bit 38.
     cdc = 38
-    PRN_a = _u(bits, cdc, 8)
+    PRN_a = Int(get_bits(word, N, cdc, 8))
     PRN_a == 0xff && return raw  # all-ones PRN ⇒ no DC data in this packet
-    δa_f0 = _s(bits, cdc + 8, 13) * 2.0^-35
-    δa_f1 = _s(bits, cdc + 21, 8) * 2.0^-51
-    UDRA_index = _s(bits, cdc + 29, 5)
+    δa_f0 = get_twos_complement_num(word, N, cdc + 8, 13) * 2.0^-35
+    δa_f1 = get_twos_complement_num(word, N, cdc + 21, 8) * 2.0^-51
+    UDRA_index = get_twos_complement_num(word, N, cdc + 29, 5)
     # EDC segment (Fig 3.5-10): PRN ID(8) Δα(14) Δβ(14) Δγ(15) Δi(12) ΔΩ(12)
     # ΔA(12) UDRA-dot(5) — starts at bit 72 (38 + 34).
     edc = 72
-    ΔαΔ = _s(bits, edc + 8, 14) * 2.0^-34
-    Δβ = _s(bits, edc + 22, 14) * 2.0^-34
-    Δγ = _s(bits, edc + 36, 15) * 2.0^-32 * PI
-    Δi = _s(bits, edc + 51, 12) * 2.0^-32 * PI
-    ΔΩ = _s(bits, edc + 63, 12) * 2.0^-32 * PI
-    ΔA = _s(bits, edc + 75, 12) * 2.0^-9
-    UDRA_dot_index = _s(bits, edc + 87, 5)
+    ΔαΔ = get_twos_complement_num(word, N, edc + 8, 14) * 2.0^-34
+    Δβ = get_twos_complement_num(word, N, edc + 22, 14) * 2.0^-34
+    Δγ = get_twos_complement_num(word, N, edc + 36, 15) * 2.0^-32 * PI
+    Δi = get_twos_complement_num(word, N, edc + 51, 12) * 2.0^-32 * PI
+    ΔΩ = get_twos_complement_num(word, N, edc + 63, 12) * 2.0^-32 * PI
+    ΔA = get_twos_complement_num(word, N, edc + 75, 12) * 2.0^-9
+    UDRA_dot_index = get_twos_complement_num(word, N, edc + 87, 5)
     dc = GPSL1C_DDifferentialCorrection(;
         PRN_a,
         t_op_D,
@@ -1132,10 +1157,11 @@ function parse_sf3_page5(raw::GPSL1C_DData, bits::AbstractVector{Bool}, PI::Floa
 end
 
 "Subframe 3, page 6 — 29 ASCII characters at bits 19-250 (IS-GPS-800J Fig 3.5-7)."
-function parse_sf3_page6(raw::GPSL1C_DData, bits::AbstractVector{Bool})
+function parse_sf3_page6(raw::GPSL1C_DData, word::UInt288)
+    N = L1C_D_SF3_INFO_BITS
     chars = Char[]
     for k in 0:28
-        code = _u(bits, 19 + 8k, 8)
+        code = Int(get_bits(word, N, 19 + 8k, 8))
         # Keep printable ASCII; skip NUL/control padding so the message is clean.
         (code >= 0x20 && code < 0x7f) && push!(chars, Char(code))
     end


### PR DESCRIPTION
## What

Migrates the GPS L1C-D (CNAV-2) decoder's subframe-2/3 bit-field extraction from `Vector{Bool}` with private `_u`/`_s` helpers to the shared `get_bits` / `get_twos_complement_num` / `get_bit` helpers operating on packed BitIntegers words — the same idiom the GPS L1 C/A and Galileo E1B decoders already use (issue #48, option 1).

## How

- **Word widths:** subframe 2's 600 info bits use a new `BitIntegers.@define_integers 600` (`UInt600`); subframe 3's 274 info bits reuse the `UInt288` already defined in `src/galileo/e1b.jl` (included before `src/gps/l1c_d.jl`). `get_bits(word, 274, …)` addresses the 274 right-aligned logical bits regardless of the wider storage, so no separate SF3 type is needed. SF2 is kept as one `UInt600` for readability (the issue benchmarks accept ~16 ns/field above 512 bits — noise at one parse per 18 s).
- **CRC location:** `ldpc_decode_word` runs the Aff3ct decode, CRC-24Q-checks the info block on the existing `Vector{Bool}` (reusing `crc24q`'s `AbstractVector{Bool}` method, so no new CRC method to unit-test), then packs MSB-first into the word. CRC failure returns `nothing` and the subframe is silently dropped — unchanged decode semantics.
- All SF2 + SF3 page parsers (`decode_subframe2`, `decode_subframe3`, `parse_sf3_page1`..`page6`, `_reduced_almanac_packet`) now take the packed word; `_u`/`_s`/`crc24q_ok`/`ldpc_decode_bits` are removed. Field start/length positions are unchanged.

## Test evidence

- Full suite: **1589/1589 pass** (the regression bar), including the committed L1C-D recording fixtures (`test/data/gps_l1c_d_prn{1,2}_symbols.bin`) and synthetic round-trips — decoded data is **byte-for-byte identical**.
- Aqua stays clean (part of the suite).
- Convention pre-verified in the REPL: `get_bits`/`get_twos_complement_num`/`get_bit` produce bit-identical results to the old `_u`/`_s` at `word_length = 600`/`274`, including 33-bit signed fields, with MSB-first right-aligned packing.

Confined to `src/gps/l1c_d.jl` + a CHANGELOG entry. No other decoder's parsing logic is touched.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)