### PR TITLE
ci(docs): skip docs deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -26,7 +26,16 @@ jobs:
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
       - name: Build and deploy
+        # Dependabot PRs run with a read-only token and no access to repo
+        # secrets, so a preview deploy would fail when pushing to gh-pages.
+        if: github.actor != 'dependabot[bot]'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+        run: julia --project=docs docs/make.jl
+      - name: Build docs (no deploy)
+        # Still verify the docs build (incl. doctests) on Dependabot PRs.
+        # Without credentials, deploydocs detects deploy criteria are not met
+        # and skips the push instead of erroring.
+        if: github.actor == 'dependabot[bot]'
         run: julia --project=docs docs/make.jl


### PR DESCRIPTION
## Problem

The `Documentation` workflow fails on every Dependabot PR (e.g. #54), erroring on:

```
git push -q upstream HEAD:gh-pages
ProcessExited(1)
```

Dependabot PRs run with a **read-only** `GITHUB_TOKEN` and no access to repo secrets (`DOCUMENTER_KEY`). Because the PR branch (`dependabot/...`) lives in the same repo, Documenter still decides it can deploy a preview and attempts the push to `gh-pages`, which fails. This is unrelated to what any given Dependabot PR bumps — it breaks all of them.

## Fix

Split the build/deploy step:

- Non-Dependabot runs: build **and** deploy as before.
- Dependabot PRs: build the docs only (still running doctests / `checkdocs` so doc breakage is caught), with no credentials in the environment. `deploydocs` detects that deploy criteria aren't met and skips the push instead of erroring.

## Follow-up

After this merges, re-trigger #54 with `@dependabot rebase` so it picks up the fixed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)