### PR TITLE
test(flexiband): self-terminate demux at first malformed frame

### DIFF
--- a/test/flexiband_iii7a.jl
+++ b/test/flexiband_iii7a.jl
@@ -139,6 +139,15 @@ else
     # `track!` boundary check needs). L1 is 4-bit two's-complement I/Q (I = high
     # nibble); the L5 byte packs two 2-bit sign-magnitude I/Q samples, sample 0
     # in the MSBs.
+    #
+    # Reading is windowed (one call per `track!` chunk) and demuxes straight from
+    # the decompressing zip stream, so only one window of samples is ever live —
+    # the full ~1.93 GB `.usb` is never materialized. The stream also
+    # self-terminates at the first malformed frame: only the first ~13.68 s of
+    # this capture is well-formed; the trailing ~2 s has broken `0x55 0xAA`
+    # preambles and demuxes to noise (cf. Tracking.jl #157/#158). We stop at the
+    # first bad preamble and return only the valid prefix rather than feeding
+    # garbage tail frames to `track!`/`decode`.
     function iii7a_read_bands!(usb, nblocks)
         frame = Vector{UInt8}(undef, III7A_BLOCK)
         l1 = Vector{ComplexF32}(undef, III7A_CYCLES * nblocks * 4)
@@ -148,7 +157,8 @@ else
         lvl(x) = @inbounds III7A_L5_LEVELS[(x&0x03)+1]
         for _ = 1:nblocks
             eof(usb) && break
-            read!(usb, frame);
+            read!(usb, frame)
+            (frame[1] == 0x55 && frame[2] == 0xAA) || break
             got += 1
             @inbounds for c = 0:(III7A_CYCLES-1)
                 base = III7A_HEADER + c * III7A_CHUNK


### PR DESCRIPTION
## What

The III-7a integration test now stops the demux at the first malformed USB frame instead of reading all the way to EOF.

## Why

The Flexiband III-7a capture is only well-formed for its first ~13.68 s; the trailing ~2 s has broken `0x55 0xAA` preambles and demuxes to noise. This is the same capture-tail artifact diagnosed in [Tracking.jl #157 / #158](https://github.com/JuliaGNSS/Tracking.jl/pull/158).

`iii7a_read_bands!` did not validate the frame preamble, so it fed those garbage tail frames into `track!`/`decode`.

## Change

- Check the `0x55 0xAA` preamble on each frame; stop at the first bad one and return only the valid prefix. When a window comes back short, the next read returns empty and the existing `isempty(l1) && break` ends the tracking loop cleanly.
- Document that the demux is already windowed — one 0.2 s chunk read straight from the decompressing zip stream, never materializing the full ~1.93 GB `.usb`, so memory stays bounded (lighter than #158's retain-then-`@view` approach; no OOM risk here).

## Notes

The integration test is opt-in (`GNSSDECODER_RUN_INTEGRATION_TEST=true`) and downloads a 1.6 GB capture, so it was not run end-to-end here. The preamble logic mirrors the verified `read_payload` in Tracking.jl #158. Change is JuliaFormatter 2.8.5 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)