### PR TITLE
feat(galileo_e1b): support the E1B BOC(1,1) signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently implemented:
  * GPS L1C-D (CNAV-2)
  * GPS L2C (CNAV)
  * GPS L5I (CNAV)
- * Galileo E1B (I/NAV)
+ * Galileo E1B (I/NAV), including the BOC(1,1) approximation
  * Galileo E5a (F/NAV)
 
 ## Installation

--- a/src/galileo/e1b.jl
+++ b/src/galileo/e1b.jl
@@ -586,6 +586,17 @@ function GNSSDecoderState(system::GalileoE1B, prn)
     GalileoE1BDecoderState(prn)
 end
 
+# GalileoE1B_BOC11 is the BOC(1,1) approximation of Galileo E1B — a lower
+# sampling-rate replica many software receivers substitute for the full
+# CBOC(6,1,1/11) spec (see GNSSSignals.jl `GalileoE1B_BOC11`). It carries the
+# *identical* I/NAV navigation message: same 4092-chip primary code, same
+# 250 bps data rate, same page/word structure. The modulation difference is a
+# tracking/acquisition concern only, so decoding reuses the E1B decoder
+# unchanged.
+function GNSSDecoderState(system::GalileoE1B_BOC11, prn)
+    GalileoE1BDecoderState(prn)
+end
+
 """
 $(TYPEDSIGNATURES)
 

--- a/test/galileo_e1b.jl
+++ b/test/galileo_e1b.jl
@@ -10,6 +10,15 @@ const GALILEO_E1B_DATA = [
     @test GalileoE1BDecoderState(21) == GNSSDecoderState(galileo_e1b, 21)
 end
 
+@testset "Galileo E1B BOC(1,1) constructor" begin
+    # The BOC(1,1) approximation carries the identical I/NAV message, so it
+    # dispatches to the same decoder state as full-CBOC Galileo E1B.
+    galileo_e1b_boc11 = GalileoE1B_BOC11()
+
+    @test GalileoE1BDecoderState(21) == GNSSDecoderState(galileo_e1b_boc11, 21)
+    @test GNSSDecoderState(GalileoE1B(), 21) == GNSSDecoderState(galileo_e1b_boc11, 21)
+end
+
 @testset "Galileo E1B test data decoding" begin
     decoder = GalileoE1BDecoderState(21)
 


### PR DESCRIPTION
## Summary

Adds decoder support for `GalileoE1B_BOC11`, the BOC(1,1) approximation of Galileo E1B introduced in GNSSSignals.jl 2.6.

Software receivers commonly substitute a pure BOC(1,1) replica for the full CBOC(6,1,1/11) spec (lower sampling rate, ~0.45 dB correlation loss). The two are distinct *signal* types in GNSSSignals.jl, but they carry the **identical I/NAV navigation message** — same 4092-chip primary code, same 250 bps data rate, same page/word structure. The difference is purely in the RF modulation, which is a tracking/acquisition concern, not a navigation-message decoding one.

Accordingly, `GNSSDecoderState(::GalileoE1B_BOC11, prn)` dispatches to the existing E1B decoder unchanged, rather than duplicating the Constants/Data/Cache/parsing stack.

## Changes

- **`src/galileo/e1b.jl`** — add `GNSSDecoderState(::GalileoE1B_BOC11, prn)` mapping to `GalileoE1BDecoderState`, with a comment explaining why the decoder is shared.
- **`test/galileo_e1b.jl`** — add a constructor testset asserting the BOC(1,1) state equals both the direct constructor and the full-CBOC E1B state.
- **`README.md`** — note the BOC(1,1) approximation under supported signals.

## Notes

- No compat bump needed — `GalileoE1B_BOC11` is present in the already-required GNSSSignals `2.6`.
- With this change, GNSSDecoder covers every **data-bearing** signal GNSSSignals.jl 2.6 defines. The remaining uncovered signals (`GPSL1C_P`, `GPSL2CL`, `GPSL5Q`, `GalileoE1C`, `GalileoE1C_BOC11`, `GalileoE5aQ`) are all dataless pilot components (`get_data_frequency == 0 Hz`) with no navigation message to decode.

## Testing

Galileo E1B test suite passes (16/16), including the 2 new BOC(1,1) constructor tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)