### PR TITLE
fix(gpsl1): screen the HOW time of week for plausibility

### DIFF
--- a/src/gps/l1ca.jl
+++ b/src/gps/l1ca.jl
@@ -92,6 +92,7 @@ subframes 1, 2, and 3 of the GPS LNAV message. All parameters conform to IS-GPS-
   - `TOW::Int64`: Time of Week at the start of the next subframe (seconds, 0-604794 in steps of 6)
   - `alert_flag::Bool`: URA may be worse than indicated (0=OK, 1=alert)
   - `anti_spoof_flag::Bool`: Anti-spoofing mode (0=off, 1=on)
+  - `num_bits_after_valid_syncro_sequence_after_last_TOW::Int`: Symbol-counter value when `TOW` was decoded
 
 # Subframe 1 - Clock Correction Parameters
 
@@ -143,6 +144,9 @@ Base.@kwdef struct GPSL1CAData <: AbstractGPSData
     TOW::Union{Nothing,Int64} = nothing
     alert_flag::Union{Nothing,Bool} = nothing
     anti_spoof_flag::Union{Nothing,Bool} = nothing
+    # `num_bits_after_valid_syncro_sequence` when `TOW` was decoded; lets
+    # `is_plausible_TOW` predict the next legal TOW exactly (issue #82).
+    num_bits_after_valid_syncro_sequence_after_last_TOW::Union{Nothing,Int} = nothing
 
     trans_week::Union{Nothing,Int64} = nothing
     codeonl2::Union{Nothing,Int64} = nothing
@@ -222,6 +226,7 @@ function GPSL1CAData(
     TOW = data.TOW,
     alert_flag = data.alert_flag,
     anti_spoof_flag = data.anti_spoof_flag,
+    num_bits_after_valid_syncro_sequence_after_last_TOW = data.num_bits_after_valid_syncro_sequence_after_last_TOW,
     trans_week = data.trans_week,
     codeonl2 = data.codeonl2,
     ura = data.ura,
@@ -282,6 +287,7 @@ function GPSL1CAData(
         TOW,
         alert_flag,
         anti_spoof_flag,
+        num_bits_after_valid_syncro_sequence_after_last_TOW,
         trans_week,
         codeonl2,
         ura,
@@ -589,7 +595,11 @@ function reset_decoder_state(state::GNSSDecoderState{<:GPSL1CAData})
     empty!(state.cache.soft_buffer)
     GNSSDecoderState(
         state;
-        raw_data = GPSL1CAData(state.raw_data; TOW = nothing),
+        raw_data = GPSL1CAData(
+            state.raw_data;
+            TOW = nothing,
+            num_bits_after_valid_syncro_sequence_after_last_TOW = nothing,
+        ),
         data = GPSL1CAData(),
         num_bits_after_valid_syncro_sequence = nothing,
     )
@@ -698,35 +708,62 @@ const SECONDS_PER_WEEK = 604_800
 # though the 17-bit field could hold counts up to 131071.
 const LNAV_MAX_TOW_COUNT = SECONDS_PER_WEEK ÷ 6 - 1
 
-# Largest forward step accepted between the TOWs of two successfully decoded
-# HOWs, in seconds. Generous against real gaps — subframes are missed when bit
-# decoding stalls through a signal blockage or words fail parity, and a full
-# signal loss resets the decoder (clearing the held TOW) anyway — while small
-# enough (~0.1% of the week) to reject nearly every false-lock TOW. A genuine
-# gap beyond this costs one discarded TOW; the next subframe is accepted fresh.
+# An LNAV subframe is 300 symbols long and lasts 6 s (50 bps).
+const LNAV_SYMBOLS_PER_SUBFRAME = 300
+
+# Fallback bound for the TOW continuity screen while the symbol counter is
+# not yet running (before the first data promotion, and after a decoder
+# reset): largest forward step accepted between the TOWs of two successfully
+# decoded HOWs, in seconds. Generous against real gaps — subframes are missed
+# when bit decoding stalls through a signal blockage or words fail parity —
+# while small enough (~0.1% of the week) to reject nearly every false-lock
+# TOW. Once the counter runs, the exact elapsed-symbols screen replaces this
+# bound. A genuine gap beyond it costs one discarded TOW; the next subframe
+# is accepted fresh.
 const LNAV_MAX_TOW_GAP = 600
 
 """
-    is_plausible_TOW(TOW_count, prev_TOW)
+    is_plausible_TOW(TOW_count, prev_TOW, prev_TOW_anchor, num_bits_after_valid_syncro_sequence)
 
 Screen a truncated time-of-week count freshly decoded from a HOW against what
 a genuine frame lock can produce, before it is stored (in seconds) in
 `raw_data.TOW`. `prev_TOW` is the TOW held from an earlier subframe's HOW in
-seconds, or `nothing` if none is held.
+seconds (`nothing` if none is held), `prev_TOW_anchor` the symbol-counter
+value recorded when it was decoded, and the last argument the counter's
+current value (`state.num_bits_after_valid_syncro_sequence`).
 
 Frame sync is only a 16-bit preamble match, so a false lock on noise
 occasionally reaches this point with an arbitrary 17-bit count behind valid
-parity (issue #82). Two screens reject most of them:
+parity (issue #82). The screens, strongest available first:
 
   - The count must lie inside the week (at most `LNAV_MAX_TOW_COUNT`).
-  - When a previous TOW is held, the new one must lie ahead of it — modulo
-    `SECONDS_PER_WEEK`, so the week rollover passes — by at most
-    `LNAV_MAX_TOW_GAP`. Consecutive subframes step by exactly 6 s, but
-    subframes may be missed, so any bounded forward step is accepted.
+  - When the symbol counter ran across both HOW decodes, the elapsed symbols
+    predict the TOW exactly: `elapsed` must be a positive multiple of
+    `LNAV_SYMBOLS_PER_SUBFRAME` — genuine locks always sit on the same
+    300-symbol frame grid — and the TOW must have advanced by 6 s per
+    subframe (modulo `SECONDS_PER_WEEK`, so the week rollover passes). This
+    holds across arbitrarily long decode gaps (a blockage, a satellite
+    concealed for hours from a vector-tracking receiver) as long as tracking
+    keeps symbols flowing, and needs no tuning constant. Should the counter
+    desync from the frame grid (a symbol slip), one genuine TOW is discarded
+    and the next is accepted fresh against an empty history.
+  - Before the counter runs there is no elapsed-time reference, so fall back
+    to a bounded forward step of at most `LNAV_MAX_TOW_GAP` seconds.
 """
-function is_plausible_TOW(TOW_count, prev_TOW)
+function is_plausible_TOW(
+    TOW_count,
+    prev_TOW,
+    prev_TOW_anchor,
+    num_bits_after_valid_syncro_sequence,
+)
     TOW_count <= LNAV_MAX_TOW_COUNT || return false
     isnothing(prev_TOW) && return true
+    if !isnothing(prev_TOW_anchor) && !isnothing(num_bits_after_valid_syncro_sequence)
+        elapsed = num_bits_after_valid_syncro_sequence - prev_TOW_anchor
+        (elapsed > 0 && elapsed % LNAV_SYMBOLS_PER_SUBFRAME == 0) || return false
+        return Int64(TOW_count) * 6 ==
+               mod(prev_TOW + 6 * (elapsed ÷ LNAV_SYMBOLS_PER_SUBFRAME), SECONDS_PER_WEEK)
+    end
     ΔTOW = mod(Int64(TOW_count) * 6 - prev_TOW, SECONDS_PER_WEEK)
     return 0 < ΔTOW <= LNAV_MAX_TOW_GAP
 end
@@ -739,17 +776,36 @@ function read_tlm_and_how_words(state, buffer)
     # `raw_data.TOW` must only ever hold a TOW decoded from *this* subframe's
     # HOW: `confirm_data` re-anchors `num_bits_after_valid_syncro_sequence` to
     # it when promoting `raw_data`, so a TOW left over from an earlier subframe
-    # would shift the reported transmit time by a multiple of 6 s. Clear it up
-    # front; a HOW that passes parity and the plausibility screen writes it back.
+    # would shift the reported transmit time by a multiple of 6 s. Clear it
+    # (and its anchor) up front; a HOW that passes parity and the plausibility
+    # screen writes them back.
     prev_TOW = state.raw_data.TOW
-    state = GNSSDecoderState(state; raw_data = GPSL1CAData(state.raw_data; TOW = nothing))
+    prev_TOW_anchor = state.raw_data.num_bits_after_valid_syncro_sequence_after_last_TOW
+    num_bits = state.num_bits_after_valid_syncro_sequence
+    state = GNSSDecoderState(
+        state;
+        raw_data = GPSL1CAData(
+            state.raw_data;
+            TOW = nothing,
+            num_bits_after_valid_syncro_sequence_after_last_TOW = nothing,
+        ),
+    )
     state = can_decode_word(state, buffer, 2) do how_word, state
         TOW_count = get_bits(how_word, 30, 1, 17)
         alert_flag = get_bit(how_word, 30, 18)
         anti_spoof_flag = get_bit(how_word, 30, 19)
         last_subframe_id = get_bits(how_word, 30, 20, 3)
-        TOW = is_plausible_TOW(TOW_count, prev_TOW) ? Int64(TOW_count) * 6 : nothing
-        GPSL1CAData(state.raw_data; last_subframe_id, TOW, alert_flag, anti_spoof_flag)
+        is_plausible = is_plausible_TOW(TOW_count, prev_TOW, prev_TOW_anchor, num_bits)
+        TOW = is_plausible ? Int64(TOW_count) * 6 : nothing
+        GPSL1CAData(
+            state.raw_data;
+            last_subframe_id,
+            TOW,
+            num_bits_after_valid_syncro_sequence_after_last_TOW = is_plausible ?
+                                                                  num_bits : nothing,
+            alert_flag,
+            anti_spoof_flag,
+        )
     end
     state
 end
@@ -1372,6 +1428,25 @@ with_old_data(state, new_old_data; kwargs...) = GNSSDecoderState(
     kwargs...,
 )
 
+# Promote `raw_data` to validated `data`, re-anchoring the symbol counter to
+# the current subframe (`preamble_length` symbols past its boundary). The TOW
+# anchor must be rebased into the same counting frame: promotion only happens
+# with a TOW decoded in this very subframe (`read_tlm_and_how_words` clears
+# stale ones), so the anchor being rebased equals the counter being replaced.
+function promote_data(state, new_old_data)
+    promoted = GPSL1CAData(
+        state.raw_data;
+        num_bits_after_valid_syncro_sequence_after_last_TOW = state.constants.preamble_length,
+    )
+    with_old_data(
+        state,
+        new_old_data;
+        raw_data = promoted,
+        data = promoted,
+        num_bits_after_valid_syncro_sequence = state.constants.preamble_length,
+    )
+end
+
 function confirm_data(state, max_vote = 20)
     old_data = state.cache.old_data
 
@@ -1392,12 +1467,7 @@ function confirm_data(state, max_vote = 20)
             # New IODC entirely
             if state.data == GPSL1CAData() # no data yet - add to cache and use data
                 new_old_data = [VotedGPSL1CAData(0, state.raw_data)]
-                return with_old_data(
-                    state,
-                    new_old_data;
-                    data = state.raw_data,
-                    num_bits_after_valid_syncro_sequence = state.constants.preamble_length,
-                )
+                return promote_data(state, new_old_data)
             else # add as new entry, don't use data yet
                 new_old_data = push!(copy(old_data), VotedGPSL1CAData(0, state.raw_data))
                 return with_old_data(state, new_old_data; raw_data = GPSL1CAData())
@@ -1429,12 +1499,7 @@ function confirm_data(state, max_vote = 20)
         updated
     end
 
-    with_old_data(
-        state,
-        new_old_data;
-        data = state.raw_data,
-        num_bits_after_valid_syncro_sequence = state.constants.preamble_length,
-    )
+    promote_data(state, new_old_data)
 end
 
 function validate_data(state::GNSSDecoderState{<:GPSL1CAData})

--- a/src/gps/l1ca.jl
+++ b/src/gps/l1ca.jl
@@ -89,7 +89,7 @@ subframes 1, 2, and 3 of the GPS LNAV message. All parameters conform to IS-GPS-
 
   - `last_subframe_id::Int`: ID of the last decoded subframe (1-5)
   - `integrity_status_flag::Bool`: LNAV data integrity status (0=OK, 1=bad)
-  - `TOW::Int64`: Time of Week at message transmission (seconds, 0-604784)
+  - `TOW::Int64`: Time of Week at the start of the next subframe (seconds, 0-604794 in steps of 6)
   - `alert_flag::Bool`: URA may be worse than indicated (0=OK, 1=alert)
   - `anti_spoof_flag::Bool`: Anti-spoofing mode (0=off, 1=on)
 
@@ -691,23 +691,65 @@ function can_decode_two_words(
     return state
 end
 
+const SECONDS_PER_WEEK = 604_800
+
+# Largest legal truncated TOW count in a HOW: the count steps once per 6 s
+# subframe and rolls over after 100799 (IS-GPS-200N, Section 20.3.3.2), even
+# though the 17-bit field could hold counts up to 131071.
+const LNAV_MAX_TOW_COUNT = SECONDS_PER_WEEK ÷ 6 - 1
+
+# Largest forward step accepted between the TOWs of two successfully decoded
+# HOWs, in seconds. Generous against real gaps — subframes are missed when bit
+# decoding stalls through a signal blockage or words fail parity, and a full
+# signal loss resets the decoder (clearing the held TOW) anyway — while small
+# enough (~0.1% of the week) to reject nearly every false-lock TOW. A genuine
+# gap beyond this costs one discarded TOW; the next subframe is accepted fresh.
+const LNAV_MAX_TOW_GAP = 600
+
+"""
+    is_plausible_TOW(TOW_count, prev_TOW)
+
+Screen a truncated time-of-week count freshly decoded from a HOW against what
+a genuine frame lock can produce, before it is stored (in seconds) in
+`raw_data.TOW`. `prev_TOW` is the TOW held from an earlier subframe's HOW in
+seconds, or `nothing` if none is held.
+
+Frame sync is only a 16-bit preamble match, so a false lock on noise
+occasionally reaches this point with an arbitrary 17-bit count behind valid
+parity (issue #82). Two screens reject most of them:
+
+  - The count must lie inside the week (at most `LNAV_MAX_TOW_COUNT`).
+  - When a previous TOW is held, the new one must lie ahead of it — modulo
+    `SECONDS_PER_WEEK`, so the week rollover passes — by at most
+    `LNAV_MAX_TOW_GAP`. Consecutive subframes step by exactly 6 s, but
+    subframes may be missed, so any bounded forward step is accepted.
+"""
+function is_plausible_TOW(TOW_count, prev_TOW)
+    TOW_count <= LNAV_MAX_TOW_COUNT || return false
+    isnothing(prev_TOW) && return true
+    ΔTOW = mod(Int64(TOW_count) * 6 - prev_TOW, SECONDS_PER_WEEK)
+    return 0 < ΔTOW <= LNAV_MAX_TOW_GAP
+end
+
 function read_tlm_and_how_words(state, buffer)
     state = can_decode_word(state, buffer, 1) do tlm_word, state
         integrity_status_flag = get_bit(tlm_word, 30, 23)
         GPSL1CAData(state.raw_data; integrity_status_flag)
     end
+    # `raw_data.TOW` must only ever hold a TOW decoded from *this* subframe's
+    # HOW: `confirm_data` re-anchors `num_bits_after_valid_syncro_sequence` to
+    # it when promoting `raw_data`, so a TOW left over from an earlier subframe
+    # would shift the reported transmit time by a multiple of 6 s. Clear it up
+    # front; a HOW that passes parity and the plausibility screen writes it back.
     prev_TOW = state.raw_data.TOW
+    state = GNSSDecoderState(state; raw_data = GPSL1CAData(state.raw_data; TOW = nothing))
     state = can_decode_word(state, buffer, 2) do how_word, state
-        TOW = get_bits(how_word, 30, 1, 17) * 6
+        TOW_count = get_bits(how_word, 30, 1, 17)
         alert_flag = get_bit(how_word, 30, 18)
         anti_spoof_flag = get_bit(how_word, 30, 19)
         last_subframe_id = get_bits(how_word, 30, 20, 3)
+        TOW = is_plausible_TOW(TOW_count, prev_TOW) ? Int64(TOW_count) * 6 : nothing
         GPSL1CAData(state.raw_data; last_subframe_id, TOW, alert_flag, anti_spoof_flag)
-    end
-    if !isnothing(prev_TOW) && prev_TOW + 1 != state.raw_data.TOW
-        # Time of week must be decodable
-        state =
-            GNSSDecoderState(state; raw_data = GPSL1CAData(state.raw_data; TOW = nothing))
     end
     state
 end

--- a/test/gpsl1.jl
+++ b/test/gpsl1.jl
@@ -522,6 +522,94 @@ end
     end
 end
 
+@testset "GPS L1 C/A TOW plausibility screen (issue #82)" begin
+    is_plausible = GNSSDecoder.is_plausible_TOW
+
+    # Out-of-week counts are impossible regardless of history: the HOW count
+    # rolls over after 100799 (IS-GPS-200N, Section 20.3.3.2). 116459 is the
+    # false-lock count from issue #82.
+    @test !is_plausible(116459, nothing)
+    @test !is_plausible(100800, nothing)
+    @test is_plausible(100799, nothing)
+    @test is_plausible(0, nothing)
+
+    # Without a held TOW any in-week count is accepted.
+    @test is_plausible(43333, nothing)
+
+    # With a held TOW: consecutive subframes step by one count (6 s), and
+    # missed subframes give larger steps that must still be accepted...
+    @test is_plausible(43334, 43333 * 6)
+    @test is_plausible(43333 + 50, 43333 * 6)
+    @test is_plausible(43333 + GNSSDecoder.LNAV_MAX_TOW_GAP ÷ 6, 43333 * 6)
+    # ...but repeated, backward, and far-future TOWs are rejected.
+    @test !is_plausible(43333, 43333 * 6)
+    @test !is_plausible(43332, 43333 * 6)
+    @test !is_plausible(43333 + GNSSDecoder.LNAV_MAX_TOW_GAP ÷ 6 + 1, 43333 * 6)
+
+    # Week rollover: the last subframes of the week hand over to count 0, 1, …
+    @test is_plausible(0, 100799 * 6)
+    @test is_plausible(1, 100799 * 6)
+end
+
+@testset "GPS L1 C/A HOW screening in read_tlm_and_how_words" begin
+    # Build parity-valid TLM and HOW words. The six parity bits of a word are
+    # unique given its 24 source data bits and bits 29-30 of the previous
+    # word, so they can be found by search; a set bit 30 in the previous word
+    # additionally complements the transmitted data bits (IS-GPS-200 20.3.5).
+    function make_word(source_data24; prev29 = false, prev30 = false)
+        data24 = prev30 ? ~UInt(source_data24) & 0xFFFFFF : UInt(source_data24)
+        for parity = UInt(0):UInt(63)
+            word = data24 << 6 | parity
+            GNSSDecoder.check_gpsl1_parity(word, prev29, prev30) && return word
+        end
+        error("no parity solution for the given word")
+    end
+
+    PUInt320 = GNSSDecoder.UInt320
+    function make_buffer(TOW_count; subframe_id = 1, break_parity = false)
+        tlm = make_word(UInt(0b10001011) << 16)
+        how = make_word(
+            UInt(TOW_count) << 7 | UInt(subframe_id) << 2;
+            prev29 = GNSSDecoder.get_bit(tlm, 30, 29),
+            prev30 = GNSSDecoder.get_bit(tlm, 30, 30),
+        )
+        break_parity && (how ⊻= UInt(1))
+        PUInt320(tlm) << (30 * 9 + 8) | PUInt320(how) << (30 * 8 + 8)
+    end
+
+    with_TOW(state, TOW) = GNSSDecoder.GNSSDecoderState(
+        state;
+        raw_data = GNSSDecoder.GPSL1CAData(state.raw_data; TOW),
+    )
+
+    fresh = GPSL1CADecoderState(1)
+
+    # Fresh state: an in-week TOW is accepted together with the HOW flags.
+    state = GNSSDecoder.read_tlm_and_how_words(fresh, make_buffer(43334))
+    @test state.raw_data.TOW == 43334 * 6
+    @test state.raw_data.last_subframe_id == 1
+    @test state.raw_data.alert_flag == false
+    @test state.raw_data.anti_spoof_flag == false
+
+    # Fresh state: issue #82's out-of-week count (698754 s of week) is
+    # rejected even though the word passes parity.
+    state = GNSSDecoder.read_tlm_and_how_words(fresh, make_buffer(116459))
+    @test isnothing(state.raw_data.TOW)
+
+    # Held TOW: the following subframe's TOW (+6 s) is accepted...
+    held = with_TOW(fresh, 43333 * 6)
+    state = GNSSDecoder.read_tlm_and_how_words(held, make_buffer(43334))
+    @test state.raw_data.TOW == 43334 * 6
+    # ...an implausible in-week jump is rejected...
+    state = GNSSDecoder.read_tlm_and_how_words(held, make_buffer(93334))
+    @test isnothing(state.raw_data.TOW)
+    # ...and a HOW failing parity clears the held TOW instead of leaving the
+    # previous subframe's value behind (it would anchor transmit time 6 s off).
+    state =
+        GNSSDecoder.read_tlm_and_how_words(held, make_buffer(43334; break_parity = true))
+    @test isnothing(state.raw_data.TOW)
+end
+
 @testset "GPS L1 C/A reset_decoder_state" begin
     decoder = GPSL1CADecoderState(1)
     state = reduce(

--- a/test/gpsl1.jl
+++ b/test/gpsl1.jl
@@ -265,6 +265,8 @@ end
         TOW = 43333 * 6,
         alert_flag = false,
         anti_spoof_flag = false,
+        # Rebased to preamble_length at every data promotion (see promote_data)
+        num_bits_after_valid_syncro_sequence_after_last_TOW = 8,
         trans_week = 58,
         codeonl2 = 1,
         ura = 2.0,
@@ -523,32 +525,61 @@ end
 end
 
 @testset "GPS L1 C/A TOW plausibility screen (issue #82)" begin
+    # Arguments: 17-bit TOW count, held TOW (s), symbol-counter value when the
+    # held TOW was decoded (anchor), current symbol-counter value.
     is_plausible = GNSSDecoder.is_plausible_TOW
 
     # Out-of-week counts are impossible regardless of history: the HOW count
     # rolls over after 100799 (IS-GPS-200N, Section 20.3.3.2). 116459 is the
     # false-lock count from issue #82.
-    @test !is_plausible(116459, nothing)
-    @test !is_plausible(100800, nothing)
-    @test is_plausible(100799, nothing)
-    @test is_plausible(0, nothing)
+    @test !is_plausible(116459, nothing, nothing, nothing)
+    @test !is_plausible(100800, nothing, nothing, nothing)
+    @test is_plausible(100799, nothing, nothing, nothing)
+    @test is_plausible(0, nothing, nothing, nothing)
 
     # Without a held TOW any in-week count is accepted.
-    @test is_plausible(43333, nothing)
+    @test is_plausible(43333, nothing, nothing, nothing)
 
-    # With a held TOW: consecutive subframes step by one count (6 s), and
-    # missed subframes give larger steps that must still be accepted...
-    @test is_plausible(43334, 43333 * 6)
-    @test is_plausible(43333 + 50, 43333 * 6)
-    @test is_plausible(43333 + GNSSDecoder.LNAV_MAX_TOW_GAP ÷ 6, 43333 * 6)
+    # Exact screen while the symbol counter runs: the TOW must advance by
+    # 6 s per 300 elapsed symbols. One subframe...
+    @test is_plausible(43334, 43333 * 6, 8, 308)
+    # ...missed subframes (the counter keeps running through them)...
+    @test is_plausible(43336, 43333 * 6, 8, 908)
+    # ...a day-long decode gap (14400 subframes)...
+    @test is_plausible(43333 + 14400, 43333 * 6, 8, 8 + 86400 * 50)
+    # ...and the week rollover.
+    @test is_plausible(0, 100799 * 6, 8, 308)
+    # A lock off the 300-symbol frame grid cannot be the same signal...
+    @test !is_plausible(43334, 43333 * 6, 8, 309)
+    # ...an aligned one must carry exactly the predicted count...
+    @test !is_plausible(43335, 43333 * 6, 8, 308)
+    @test !is_plausible(43333, 43333 * 6, 8, 308)
+    # ...and time must actually have passed.
+    @test !is_plausible(43334, 43333 * 6, 8, 8)
+
+    # Fallback before the counter runs (no anchor yet): bounded forward step.
+    @test is_plausible(43334, 43333 * 6, nothing, nothing)
+    @test is_plausible(43333 + 50, 43333 * 6, nothing, nothing)
+    @test is_plausible(
+        43333 + GNSSDecoder.LNAV_MAX_TOW_GAP ÷ 6,
+        43333 * 6,
+        nothing,
+        nothing,
+    )
     # ...but repeated, backward, and far-future TOWs are rejected.
-    @test !is_plausible(43333, 43333 * 6)
-    @test !is_plausible(43332, 43333 * 6)
-    @test !is_plausible(43333 + GNSSDecoder.LNAV_MAX_TOW_GAP ÷ 6 + 1, 43333 * 6)
+    @test !is_plausible(43333, 43333 * 6, nothing, nothing)
+    @test !is_plausible(43332, 43333 * 6, nothing, nothing)
+    @test !is_plausible(
+        43333 + GNSSDecoder.LNAV_MAX_TOW_GAP ÷ 6 + 1,
+        43333 * 6,
+        nothing,
+        nothing,
+    )
 
-    # Week rollover: the last subframes of the week hand over to count 0, 1, …
-    @test is_plausible(0, 100799 * 6)
-    @test is_plausible(1, 100799 * 6)
+    # Week rollover through the fallback: the last subframes of the week hand
+    # over to count 0, 1, …
+    @test is_plausible(0, 100799 * 6, nothing, nothing)
+    @test is_plausible(1, 100799 * 6, nothing, nothing)
 end
 
 @testset "GPS L1 C/A HOW screening in read_tlm_and_how_words" begin
@@ -577,10 +608,16 @@ end
         PUInt320(tlm) << (30 * 9 + 8) | PUInt320(how) << (30 * 8 + 8)
     end
 
-    with_TOW(state, TOW) = GNSSDecoder.GNSSDecoderState(
-        state;
-        raw_data = GNSSDecoder.GPSL1CAData(state.raw_data; TOW),
-    )
+    with_TOW(state, TOW; anchor = nothing, num_bits = nothing) =
+        GNSSDecoder.GNSSDecoderState(
+            state;
+            raw_data = GNSSDecoder.GPSL1CAData(
+                state.raw_data;
+                TOW,
+                num_bits_after_valid_syncro_sequence_after_last_TOW = anchor,
+            ),
+            num_bits_after_valid_syncro_sequence = num_bits,
+        )
 
     fresh = GPSL1CADecoderState(1)
 
@@ -596,10 +633,12 @@ end
     state = GNSSDecoder.read_tlm_and_how_words(fresh, make_buffer(116459))
     @test isnothing(state.raw_data.TOW)
 
-    # Held TOW: the following subframe's TOW (+6 s) is accepted...
+    # Held TOW, symbol counter not yet running (fallback tier): the following
+    # subframe's TOW (+6 s) is accepted...
     held = with_TOW(fresh, 43333 * 6)
     state = GNSSDecoder.read_tlm_and_how_words(held, make_buffer(43334))
     @test state.raw_data.TOW == 43334 * 6
+    @test isnothing(state.raw_data.num_bits_after_valid_syncro_sequence_after_last_TOW)
     # ...an implausible in-week jump is rejected...
     state = GNSSDecoder.read_tlm_and_how_words(held, make_buffer(93334))
     @test isnothing(state.raw_data.TOW)
@@ -608,6 +647,26 @@ end
     state =
         GNSSDecoder.read_tlm_and_how_words(held, make_buffer(43334; break_parity = true))
     @test isnothing(state.raw_data.TOW)
+
+    # Once the symbol counter runs (after the first data promotion), the exact
+    # elapsed-symbols screen replaces the bounded gap. The held TOW was
+    # anchored at counter value 8, so at counter 308 (one subframe later) only
+    # the +6 s TOW fits the frame grid, and the accepted TOW records the
+    # counter value as its own anchor...
+    anchored = with_TOW(fresh, 43333 * 6; anchor = 8, num_bits = 308)
+    state = GNSSDecoder.read_tlm_and_how_words(anchored, make_buffer(43334))
+    @test state.raw_data.TOW == 43334 * 6
+    @test state.raw_data.num_bits_after_valid_syncro_sequence_after_last_TOW == 308
+    # ...a small jump the fallback tier would have accepted is now rejected...
+    state = GNSSDecoder.read_tlm_and_how_words(anchored, make_buffer(43335))
+    @test isnothing(state.raw_data.TOW)
+    @test isnothing(state.raw_data.num_bits_after_valid_syncro_sequence_after_last_TOW)
+    # ...while a day-long decode gap with tracking maintained (e.g. a
+    # concealed satellite in a vector-tracking receiver) is accepted on the
+    # first reappearing subframe.
+    concealed = with_TOW(fresh, 43333 * 6; anchor = 8, num_bits = 8 + 86400 * 50)
+    state = GNSSDecoder.read_tlm_and_how_words(concealed, make_buffer(43333 + 14400))
+    @test state.raw_data.TOW == (43333 + 14400) * 6
 end
 
 @testset "GPS L1 C/A reset_decoder_state" begin
@@ -623,6 +682,7 @@ end
     state = reset_decoder_state(state)
     @test length(state.cache.soft_buffer) == 0
     @test isnothing(state.raw_data.TOW)
+    @test isnothing(state.raw_data.num_bits_after_valid_syncro_sequence_after_last_TOW)
     @test isnothing(state.data.TOW)
     @test GNSSDecoder.num_bits_buffered(state) == 0
     @test isnothing(state.num_bits_after_valid_syncro_sequence)


### PR DESCRIPTION
## Summary

Fixes #82.

The TOW continuity check in `read_tlm_and_how_words` compared the stored TOW (seconds, in multiples of 6) against `prev_TOW + 1` — a condition no pair of TOWs can satisfy. It therefore never validated anything: whenever a previous TOW was held, the fresh one was nulled, and whenever none was held, an arbitrary 17-bit count was accepted unscreened. A false frame lock on noise (16 preamble bits plus one word's 6 parity bits) could thus inject a structurally impossible TOW, e.g. count 116459 = 698754 s of week when the count rolls over after 100799 (IS-GPS-200N 20.3.3.2).

## Changes

**Commit 1 — plausibility screens** (`ae6cfde`)

Replace the broken check with two screens applied before the TOW is stored:

- the raw count must lie inside the week (≤ 100799); ~23% of the 17-bit field is structurally impossible and is rejected outright,
- when a TOW from an earlier subframe is held, the new one must lie ahead of it (modulo the week, so the rollover passes) by at most `LNAV_MAX_TOW_GAP = 600` s.

A HOW that fails parity (or the screens) now explicitly clears the held TOW rather than leaving the previous subframe's value behind: `confirm_data` re-anchors the symbol counter when promoting `raw_data`, so a stale TOW would shift the reported transmit time by a multiple of 6 s.

**Commit 2 — exact prediction from elapsed symbols** (`321125a`)

The bounded gap has no way to know how much time really passed between two decoded HOWs — but the symbol counter (`num_bits_after_valid_syncro_sequence`) does: it keeps running at 50 symbols/s through decode gaps as long as tracking feeds symbols in. Record its value alongside each accepted TOW in a new `GPSL1CAData` field, `num_bits_after_valid_syncro_sequence_after_last_TOW` (the same anchor the Galileo E1B/E5a decoders already carry). While the counter runs, the continuity screen becomes exact: the elapsed symbol count must be a positive multiple of 300 — genuine locks always sit on the same 300-symbol frame grid, which alone rejects 299 of 300 false locks — and the TOW must have advanced by 6 s per subframe, modulo the week.

This holds across arbitrarily long decode gaps (a signal blockage, a satellite concealed for hours from a vector-tracking receiver) with no penalty on the first reappearing subframe, and needs no tuning constant. The 600 s bound remains only as the fallback tier for while the counter is not yet running (before the first data promotion, and after a decoder reset), where no elapsed-time reference exists.

Should the counter desync from the frame grid (a symbol slip), one genuine TOW is discarded and the next is accepted fresh, as before.

Also corrects the documented TOW range (max is 100799 × 6 = 604794 s, not 604784) and notes it refers to the start of the next subframe.

## Testing

- New unit tests for `is_plausible_TOW`: both tiers, week rollover, the issue #82 count, and rejection of repeated/backward/off-grid TOWs.
- New tests for `read_tlm_and_how_words` with parity-valid synthetic TLM/HOW words: acceptance, rejection, parity-failure clearing, anchor recording, and a day-long decode gap.
- Full suite passes: 2679/2679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)